### PR TITLE
Configure Firebase deployment workflow

### DIFF
--- a/.github/workflows/firebase-hosting.yml
+++ b/.github/workflows/firebase-hosting.yml
@@ -1,0 +1,26 @@
+name: Deploy to Firebase Hosting
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm ci
+        working-directory: Orynth
+      - run: npm run build
+        working-directory: Orynth
+      - uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: '${{ secrets.GITHUB_TOKEN }}'
+          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}'
+          entryPoint: Orynth
+          projectId: orynth-io
+          channelId: live

--- a/Orynth/firebase.json
+++ b/Orynth/firebase.json
@@ -1,6 +1,6 @@
 {
   "hosting": {
-    "public": "public",
+    "public": "dist/Orynth",
     "ignore": [
       "firebase.json",
       "**/.*",

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # Orynth
 Organic Rhythm for Growth - Your study tracker app
+
+## Deployment
+
+This repository uses a GitHub Actions workflow to deploy the Angular project to Firebase Hosting.
+Pushes to the `main` branch run the workflow in `.github/workflows/firebase-hosting.yml`, which
+builds the project from the `Orynth` directory and deploys it using the service account defined in
+`secrets.FIREBASE_SERVICE_ACCOUNT`.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to deploy to Firebase on pushes to main
- fix firebase.json to serve built Angular output
- document deployment in README

## Testing
- `npm test` *(fails: cannot find module './compile.js')*

------
https://chatgpt.com/codex/tasks/task_e_685ff75ae33c832eb6f02ebd93b025f8