### PR TITLE
Fix Node version for Angular 20

### DIFF
--- a/.github/workflows/firebase-hosting.yml
+++ b/.github/workflows/firebase-hosting.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
       - run: npm ci
         working-directory: Orynth
       - run: npm run build

--- a/Orynth/package-lock.json
+++ b/Orynth/package-lock.json
@@ -3887,16 +3887,17 @@
       }
     },
     "node_modules/css-select": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.1.tgz",
-      "integrity": "sha512-O5tBe98mNUxm2ovZAqJ6uZqo1qVWrKAMQMf9uTK+M321MKKYX+cOORH3xvu17tYRuRM3mjJclcp/y4PNoI3U/A==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0",
         "css-what": "^6.1.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.2.2",
-        "nth-check": "^2.1.1"
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"

--- a/Orynth/package.json
+++ b/Orynth/package.json
@@ -42,5 +42,8 @@
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
     "typescript": "~5.8.2"
+  },
+  "overrides": {
+    "css-select": "5.2.2"
   }
 }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Organic Rhythm for Growth - Your study tracker app
 
 ## Deployment
 
-This repository uses a GitHub Actions workflow to deploy the Angular project to Firebase Hosting.
+This repository uses a GitHub Actions workflow to deploy the Angular project to Firebase Hosting. The project targets Angular CLI v20, which requires Node.js v20 or newer.
 Pushes to the `main` branch run the workflow in `.github/workflows/firebase-hosting.yml`, which
 builds the project from the `Orynth` directory and deploys it using the service account defined in
 `secrets.FIREBASE_SERVICE_ACCOUNT`.


### PR DESCRIPTION
## Summary
- require Node 20 in deployment workflow
- note Node 20 requirement in README
- override `css-select` to 5.2.2 for Angular build

## Testing
- `npm install`
- `npm run build`
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_686010835bac832eb960a68985eb810a