### PR TITLE
Fix Firebase hosting path

### DIFF
--- a/Orynth/firebase.json
+++ b/Orynth/firebase.json
@@ -1,6 +1,6 @@
 {
   "hosting": {
-    "public": "dist/Orynth",
+    "public": "dist/Orynth/browser",
     "ignore": [
       "firebase.json",
       "**/.*",


### PR DESCRIPTION
## Summary
- point Firebase hosting `public` directory to `dist/Orynth/browser`

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_686020924524832ea37f449b1d322814