### PR TITLE
Align Angular pages with sample prototype

### DIFF
--- a/Orynth/src/app/pages/board-class-selection/board-class-selection-page.html
+++ b/Orynth/src/app/pages/board-class-selection/board-class-selection-page.html
@@ -1,19 +1,47 @@
-<div class="p-4 flex flex-col gap-4">
-  <label class="flex flex-col">
-    <span class="mb-1">Board</span>
-    <select [(ngModel)]="board" class="p-2 border rounded-md">
-      <option value="CBSE">CBSE</option>
-      <option value="ICSE">ICSE</option>
-      <option value="State">State</option>
-    </select>
-  </label>
+<div class="min-h-screen bg-gradient-to-br from-blue-50 to-green-50 flex flex-col">
+  <div class="flex items-center justify-between p-4">
+    <button (click)="step === 1 ? goHome() : step = 1" class="p-2 hover:bg-white/20 rounded-full tap-highlight">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-6 h-6 text-gray-700">
+        <polyline points="15 18 9 12 15 6"></polyline>
+      </svg>
+    </button>
+    <div class="flex space-x-2">
+      <div class="w-8 h-2 rounded-full" [ngClass]="step >= 1 ? 'bg-primary' : 'bg-gray-300'"></div>
+      <div class="w-8 h-2 rounded-full" [ngClass]="step >= 2 ? 'bg-primary' : 'bg-gray-300'"></div>
+    </div>
+  </div>
 
-  <label class="flex flex-col">
-    <span class="mb-1">Class</span>
-    <select [(ngModel)]="clazz" class="p-2 border rounded-md">
-      <option *ngFor="let c of classes" [value]="c">{{ c }}</option>
-    </select>
-  </label>
+  <div class="flex-1 px-6 pt-8">
+    <div class="max-w-sm mx-auto">
+      <ng-container *ngIf="step === 1; else classStep">
+        <div class="animate-fade-in">
+          <h1 class="text-2xl font-bold text-gray-900 mb-2">Select Your Board</h1>
+          <p class="text-gray-600 mb-8">Choose your education board to get started</p>
+          <div class="space-y-4">
+            <button *ngFor="let board of boards" (click)="selectedBoard = board.id" class="w-full p-4 rounded-xl text-left transition-all tap-highlight" [ngClass]="selectedBoard === board.id ? 'bg-primary text-white card-shadow-hover' : 'bg-white card-shadow hover:card-shadow-hover'">
+              <h3 class="font-semibold text-lg">{{ board.name }}</h3>
+              <p class="text-sm" [ngClass]="selectedBoard === board.id ? 'text-white/80' : 'text-gray-600'">{{ board.description }}</p>
+            </button>
+          </div>
+        </div>
+      </ng-container>
 
-  <app-button routerLink="/subject-list">Continue</app-button>
+      <ng-template #classStep>
+        <div class="animate-fade-in">
+          <h1 class="text-2xl font-bold text-gray-900 mb-2">Select Your Class</h1>
+          <p class="text-gray-600 mb-8">Choose your current class level</p>
+          <div class="grid grid-cols-3 gap-4">
+            <button *ngFor="let c of classes" (click)="selectedClass = c" class="aspect-square rounded-xl font-semibold text-lg transition-all tap-highlight" [ngClass]="selectedClass === c ? 'bg-primary text-white card-shadow-hover' : 'bg-white card-shadow hover:card-shadow-hover text-gray-900'">
+              Class {{ c }}
+            </button>
+          </div>
+        </div>
+      </ng-template>
+    </div>
+  </div>
+
+  <div class="p-6">
+    <button *ngIf="step === 1" (click)="step = 2" [disabled]="!selectedBoard" class="w-full h-14 text-lg font-semibold bg-primary hover:bg-primary/90 text-white rounded-xl card-shadow hover:card-shadow-hover tap-highlight disabled:opacity-50 disabled:cursor-not-allowed">Continue</button>
+    <a *ngIf="step === 2" [routerLink]="'/subject-list'" [class.disabled]="!selectedClass" class="w-full h-14 flex items-center justify-center text-lg font-semibold bg-primary hover:bg-primary/90 text-white rounded-xl card-shadow hover:card-shadow-hover tap-highlight disabled:opacity-50 disabled:cursor-not-allowed" [class.pointer-events-none]="!selectedClass">Start Learning</a>
+  </div>
 </div>

--- a/Orynth/src/app/pages/board-class-selection/board-class-selection-page.ts
+++ b/Orynth/src/app/pages/board-class-selection/board-class-selection-page.ts
@@ -1,17 +1,26 @@
 import { Component } from '@angular/core';
-import { FormsModule } from '@angular/forms';
-import { RouterModule } from '@angular/router';
-import { ButtonComponent } from '../../components/button/button';
+import { CommonModule } from '@angular/common';
+import { RouterModule, Router } from '@angular/router';
 
 @Component({
   selector: 'app-board-class-selection-page',
-  imports: [FormsModule, RouterModule, ButtonComponent],
-  templateUrl: './board-class-selection-page.html',
-  styleUrl: './board-class-selection-page.scss'
+  imports: [CommonModule, RouterModule],
+  templateUrl: './board-class-selection-page.html'
 })
 export class BoardClassSelectionPageComponent {
+  step: 1 | 2 = 1;
+  selectedBoard = '';
+  selectedClass = '';
+  boards = [
+    { id: 'cbse', name: 'CBSE', description: 'Central Board of Secondary Education' },
+    { id: 'icse', name: 'ICSE', description: 'Indian Certificate of Secondary Education' },
+    { id: 'state', name: 'State Board', description: 'State Government Board' }
+  ];
+  classes = ['6', '7', '8', '9', '10', '11', '12'];
 
-  board = 'CBSE';
-  clazz = 6;
-  classes = [6, 7, 8, 9, 10, 11, 12];
+  constructor(private router: Router) {}
+
+  goHome() {
+    this.router.navigate(['/']);
+  }
 }

--- a/Orynth/src/app/pages/onboarding/onboarding-page.html
+++ b/Orynth/src/app/pages/onboarding/onboarding-page.html
@@ -1,23 +1,83 @@
-<div class="min-h-screen flex items-center justify-center p-4 bg-gradient-to-b from-white via-gray-50 to-gray-100">
-  <div class="w-full max-w-md text-center space-y-6">
-    <div class="mx-auto flex items-center justify-center w-16 h-16 rounded-full bg-green-100">
-      <!-- Placeholder icon -->
-      <svg class="w-10 h-10 text-green-600" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-        <circle cx="12" cy="12" r="10" />
+<div class="min-h-screen bg-gradient-to-br from-blue-50 to-green-50 flex flex-col">
+  <div class="text-center pt-16 pb-8">
+    <div class="w-16 h-16 bg-primary rounded-full flex items-center justify-center mx-auto mb-6 animate-scale-in">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        class="w-8 h-8 text-white"
+      >
+        <path d="M12 7v14" />
+        <path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z" />
       </svg>
     </div>
-    <h1 class="text-4xl font-bold font-rounded">Orynth</h1>
-    <h2 class="text-xl font-rounded">Welcome to your learning journey</h2>
-    <p class="text-gray-700">Track your progress, master every chapter, and build lasting confidence in your studies.</p>
-    <ul class="text-left space-y-2 list-disc list-inside">
-      <li>Track Progress: <span class="ml-1">Monitor your learning across all subjects</span></li>
-      <li>Build Confidence: <span class="ml-1">Rate your understanding of each topic</span></li>
-    </ul>
-    <a
-      routerLink="/board-class-selection"
-      class="block w-full sm:w-auto px-4 py-2 rounded-md bg-green-600 text-white font-rounded transition-colors hover:bg-green-700 active:bg-green-800"
-    >
-      Start Tracking
-    </a>
+    <h1 class="text-2xl font-bold text-gray-900 mb-2 animate-fade-in">LearnTrack</h1>
+    <p class="text-sm text-gray-600 animate-fade-in">Track your learning. Build confidence.</p>
   </div>
+
+  <div class="flex-1 flex flex-col justify-center px-6 pb-20">
+    <div class="max-w-sm mx-auto w-full">
+      <div class="text-center mb-12 animate-slide-up">
+        <h2 class="text-3xl font-bold text-gray-900 mb-4 leading-tight">Welcome to your learning journey</h2>
+        <p class="text-gray-600 text-lg mb-8">Track your progress, master every chapter, and build lasting confidence in your studies.</p>
+      </div>
+
+      <div class="space-y-4 mb-12">
+        <div class="flex items-center space-x-4 animate-fade-in" style="animation-delay:0.2s">
+          <div class="w-10 h-10 bg-success-light rounded-full flex items-center justify-center">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              class="w-5 h-5 text-success"
+            >
+              <circle cx="12" cy="12" r="10" />
+              <line x1="12" y1="8" x2="12" y2="16" />
+              <line x1="8" y1="12" x2="16" y2="12" />
+            </svg>
+          </div>
+          <div>
+            <p class="font-medium text-gray-900">Track Progress</p>
+            <p class="text-sm text-gray-600">Monitor your learning across all subjects</p>
+          </div>
+        </div>
+
+        <div class="flex items-center space-x-4 animate-fade-in" style="animation-delay:0.4s">
+          <div class="w-10 h-10 bg-warning-light rounded-full flex items-center justify-center">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              class="w-5 h-5 text-warning"
+            >
+              <polyline points="16 18 22 12 16 6" />
+              <polyline points="8 6 2 12 8 18" />
+            </svg>
+          </div>
+          <div>
+            <p class="font-medium text-gray-900">Build Confidence</p>
+            <p class="text-sm text-gray-600">Rate your understanding of each topic</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="animate-slide-up" style="animation-delay:0.6s">
+        <a routerLink="/board-class-selection" class="w-full h-14 flex items-center justify-center text-lg font-semibold bg-primary hover:bg-primary/90 text-white rounded-xl card-shadow hover:card-shadow-hover tap-highlight">Start Tracking</a>
+      </div>
+    </div>
+  </div>
+
+  <div class="absolute bottom-0 left-0 right-0 h-32 bg-gradient-to-t from-white/20 to-transparent pointer-events-none"></div>
 </div>

--- a/Orynth/src/app/pages/onboarding/onboarding-page.scss
+++ b/Orynth/src/app/pages/onboarding/onboarding-page.scss
@@ -1,5 +1,0 @@
-
-ul li::marker {
-  color: theme('colors.green.600');
-}
-

--- a/Orynth/src/app/pages/onboarding/onboarding-page.ts
+++ b/Orynth/src/app/pages/onboarding/onboarding-page.ts
@@ -1,12 +1,10 @@
 import { Component } from '@angular/core';
 import { RouterModule } from '@angular/router';
-import { ButtonComponent } from '../../components/button/button';
 
 @Component({
   selector: 'app-onboarding-page',
-  imports: [RouterModule, ButtonComponent],
-  templateUrl: './onboarding-page.html',
-  styleUrl: './onboarding-page.scss'
+  imports: [RouterModule],
+  templateUrl: './onboarding-page.html'
 })
 export class OnboardingPageComponent {
 

--- a/Orynth/src/styles.scss
+++ b/Orynth/src/styles.scss
@@ -1,9 +1,58 @@
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap');
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
+/* Design system variables and utilities */
 @layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 222.2 84% 4.9%;
+    --card: 0 0% 100%;
+    --card-foreground: 222.2 84% 4.9%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 222.2 84% 4.9%;
+    --primary: 142 76% 36%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+    --muted: 210 40% 96.1%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+    --accent: 210 40% 96.1%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 214.3 31.8% 91.4%;
+    --input: 214.3 31.8% 91.4%;
+    --ring: 222.2 84% 4.9%;
+    --radius: 0.75rem;
+    --success: 142 76% 36%;
+    --success-light: 142 76% 96%;
+    --warning: 25 95% 53%;
+    --warning-light: 25 95% 96%;
+    --info: 217 91% 60%;
+    --info-light: 217 91% 96%;
+    --pending: 220 13% 69%;
+    --pending-light: 220 13% 95%;
+  }
+
+  * {
+    @apply border-border;
+  }
+
   body {
-    @apply font-sans text-md;
+    @apply bg-background text-foreground font-poppins;
+  }
+}
+
+@layer utilities {
+  .tap-highlight {
+    @apply transition-all duration-200 active:scale-95;
+  }
+  .card-shadow {
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -1px rgba(0, 0, 0, 0.03);
+  }
+  .card-shadow-hover {
+    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.08), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
   }
 }

--- a/Orynth/tailwind.config.js
+++ b/Orynth/tailwind.config.js
@@ -7,7 +7,28 @@ module.exports = {
       colors: {
         done: '#00A86B',
         inprogress: '#FFA500',
-        pending: '#808080'
+        pending: '#808080',
+        primary: 'hsl(var(--primary))',
+        'primary-foreground': 'hsl(var(--primary-foreground))',
+        success: {
+          DEFAULT: 'hsl(var(--success))',
+          light: 'hsl(var(--success-light))'
+        },
+        warning: {
+          DEFAULT: 'hsl(var(--warning))',
+          light: 'hsl(var(--warning-light))'
+        },
+        info: {
+          DEFAULT: 'hsl(var(--info))',
+          light: 'hsl(var(--info-light))'
+        },
+        pending: {
+          DEFAULT: 'hsl(var(--pending))',
+          light: 'hsl(var(--pending-light))'
+        },
+        border: 'hsl(var(--border))',
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))'
       },
       fontFamily: {
         sans: ['Inter', 'sans-serif'],
@@ -31,6 +52,25 @@ module.exports = {
       boxShadow: {
         card: '0 1px 2px rgba(0,0,0,0.05)',
         'card-lg': '0 4px 6px rgba(0,0,0,0.1)'
+      },
+      keyframes: {
+        'fade-in': {
+          '0%': { opacity: '0', transform: 'translateY(10px)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' }
+        },
+        'scale-in': {
+          '0%': { transform: 'scale(0.95)', opacity: '0' },
+          '100%': { transform: 'scale(1)', opacity: '1' }
+        },
+        'slide-up': {
+          '0%': { transform: 'translateY(20px)', opacity: '0' },
+          '100%': { transform: 'translateY(0)', opacity: '1' }
+        }
+      },
+      animation: {
+        'fade-in': 'fade-in 0.3s ease-out',
+        'scale-in': 'scale-in 0.2s ease-out',
+        'slide-up': 'slide-up 0.4s ease-out'
       },
       transitionProperty: {
         'height': 'height',

--- a/Orynth/tsconfig.app.json
+++ b/Orynth/tsconfig.app.json
@@ -10,6 +10,7 @@
     "src/**/*.ts"
   ],
   "exclude": [
-    "src/**/*.spec.ts"
+    "src/**/*.spec.ts",
+    "src/app/sample/**/*"
   ]
 }


### PR DESCRIPTION
## Summary
- add sample design variables and utilities to global styles
- expand Tailwind config with colors and animations
- implement onboarding screen using sample markup
- update board selection screen to match prototype
- exclude sample React files from compilation

## Testing
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860614c2ca4832eb193dc1811a9f67d