### PR TITLE
Fix build issues and clarify CLI setup

### DIFF
--- a/Orynth/README.md
+++ b/Orynth/README.md
@@ -2,6 +2,12 @@
 
 This project was generated using [Angular CLI](https://github.com/angular/angular-cli) version 20.0.4.
 
+Before running Angular CLI commands, install dependencies using:
+
+```bash
+npm ci
+```
+
 ## Development server
 
 To start a local development server, run:

--- a/Orynth/src/styles.scss
+++ b/Orynth/src/styles.scss
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap');
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -41,7 +40,7 @@
   }
 
   body {
-    @apply bg-background text-foreground font-poppins;
+    @apply bg-background text-foreground font-rounded;
   }
 }
 

--- a/Orynth/tsconfig.spec.json
+++ b/Orynth/tsconfig.spec.json
@@ -10,5 +10,8 @@
   },
   "include": [
     "src/**/*.ts"
+  ],
+  "exclude": [
+    "src/app/sample/**/*"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -8,5 +8,13 @@ Pushes to the `main` branch run the workflow in `.github/workflows/firebase-host
 builds the project from the `Orynth` directory and deploys it using the service account defined in
 `secrets.FIREBASE_SERVICE_ACCOUNT`.
 
+## Local setup
 
-Lovable repo is present under sample folder
+Before running Angular CLI commands such as `ng serve` or `npm run build`, install the project dependencies:
+
+```bash
+cd Orynth
+npm ci
+```
+
+This installs `@angular/cli` locally so the `ng` command is available.


### PR DESCRIPTION
## Summary
- clarify that `npm ci` installs Angular CLI for local commands
- exclude sample folder from `tsconfig.spec.json`
- remove Google font import and use `font-rounded`

## Testing
- `npm run build`
- `npm test -- --watch=false` *(fails: Chrome missing)*
- `npx ng version`


------
https://chatgpt.com/codex/tasks/task_e_6860666be2b0832e86a39b9a442823ea