### PR TITLE
Fix build by avoiding arrow functions in Angular template

### DIFF
--- a/Orynth/src/app/pages/chapter-tracker/chapter-tracker-page.html
+++ b/Orynth/src/app/pages/chapter-tracker/chapter-tracker-page.html
@@ -19,10 +19,10 @@
       <div class="bg-white rounded-xl p-4 card-shadow mb-6 animate-fade-in">
         <div class="flex justify-between items-center mb-3">
           <h3 class="font-semibold text-gray-900">Progress Summary</h3>
-          <span class="text-sm text-gray-600">{{ chapters.filter(c => c.status === 'done').length }}/{{ chapters.length }} Complete</span>
+          <span class="text-sm text-gray-600">{{ completedCount }}/{{ chapters.length }} Complete</span>
         </div>
         <div class="bg-gray-200 rounded-full h-3">
-          <div class="bg-primary h-3 rounded-full transition-all" [style.width]="(chapters.filter(c => c.status === 'done').length / chapters.length * 100) + '%'"></div>
+          <div class="bg-primary h-3 rounded-full transition-all" [style.width]="completionPercentage + '%'" ></div>
         </div>
       </div>
 

--- a/Orynth/src/app/pages/chapter-tracker/chapter-tracker-page.ts
+++ b/Orynth/src/app/pages/chapter-tracker/chapter-tracker-page.ts
@@ -16,4 +16,14 @@ export class ChapterTrackerPageComponent {
     { id: 2, name: 'Chapter 2', status: 'in-progress', confidence: 50 },
     { id: 3, name: 'Chapter 3', status: 'done', confidence: 80 }
   ];
+
+  get completedCount(): number {
+    return this.chapters.filter(c => c.status === 'done').length;
+  }
+
+  get completionPercentage(): number {
+    return this.chapters.length === 0
+      ? 0
+      : (this.completedCount / this.chapters.length) * 100;
+  }
 }


### PR DESCRIPTION
## Summary
- compute chapter progress in component class
- reference getters instead of arrow functions in the template

## Testing
- `npm run build`
- `npm run test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6860baddf0a4832ebff54a6cfa597d8e