### PR TITLE
Implement syllabus API integration

### DIFF
--- a/Orynth/src/app/app.config.ts
+++ b/Orynth/src/app/app.config.ts
@@ -1,4 +1,5 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
 import { provideServiceWorker } from '@angular/service-worker';
 import { provideRouter } from '@angular/router';
 import { provideFirebaseApp, initializeApp } from '@angular/fire/app';
@@ -14,6 +15,7 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideZoneChangeDetection({ eventCoalescing: true }),
+    provideHttpClient(),
     provideRouter(routes),
     provideServiceWorker('ngsw-worker.js', { enabled: environment.production }),
     provideFirebaseApp(() => initializeApp(environment.firebase)),

--- a/Orynth/src/app/pages/board-class-selection/board-class-selection-page.html
+++ b/Orynth/src/app/pages/board-class-selection/board-class-selection-page.html
@@ -42,6 +42,6 @@
 
   <div class="p-6">
     <button *ngIf="step === 1" (click)="step = 2" [disabled]="!selectedBoard" class="w-full h-14 text-lg font-semibold bg-primary hover:bg-primary/90 text-white rounded-xl card-shadow hover:card-shadow-hover tap-highlight disabled:opacity-50 disabled:cursor-not-allowed">Continue</button>
-    <a *ngIf="step === 2" [routerLink]="'/subject-list'" [class.disabled]="!selectedClass" class="w-full h-14 flex items-center justify-center text-lg font-semibold bg-primary hover:bg-primary/90 text-white rounded-xl card-shadow hover:card-shadow-hover tap-highlight disabled:opacity-50 disabled:cursor-not-allowed" [class.pointer-events-none]="!selectedClass">Start Learning</a>
+    <button *ngIf="step === 2" (click)="startLearning()" [disabled]="!selectedClass" class="w-full h-14 flex items-center justify-center text-lg font-semibold bg-primary hover:bg-primary/90 text-white rounded-xl card-shadow hover:card-shadow-hover tap-highlight disabled:opacity-50 disabled:cursor-not-allowed">Start Learning</button>
   </div>
 </div>

--- a/Orynth/src/app/pages/board-class-selection/board-class-selection-page.ts
+++ b/Orynth/src/app/pages/board-class-selection/board-class-selection-page.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule, Router } from '@angular/router';
+import { AppStateService } from '../../services/app-state.service';
 
 @Component({
   selector: 'app-board-class-selection-page',
@@ -18,7 +19,13 @@ export class BoardClassSelectionPageComponent {
   ];
   classes = ['6', '7', '8', '9', '10', '11', '12'];
 
-  constructor(private router: Router) {}
+  constructor(private router: Router, private appState: AppStateService) {}
+
+  startLearning() {
+    this.appState.setBoard(this.selectedBoard);
+    this.appState.setStandard(this.selectedClass);
+    this.router.navigate(['/subject-list']);
+  }
 
   goHome() {
     this.router.navigate(['/']);

--- a/Orynth/src/app/pages/chapter-tracker/chapter-tracker-page.html
+++ b/Orynth/src/app/pages/chapter-tracker/chapter-tracker-page.html
@@ -7,7 +7,7 @@
         </svg>
       </a>
       <div class="text-center">
-        <h1 class="text-lg font-semibold text-gray-900">SUBJECT</h1>
+        <h1 class="text-lg font-semibold text-gray-900">{{ subject }}</h1>
         <p class="text-sm text-gray-600">Track your progress</p>
       </div>
       <div class="w-10"></div>

--- a/Orynth/src/app/pages/chapter-tracker/chapter-tracker-page.ts
+++ b/Orynth/src/app/pages/chapter-tracker/chapter-tracker-page.ts
@@ -1,7 +1,9 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { ChipComponent } from '../../components/chip/chip';
+import { AppStateService } from '../../services/app-state.service';
+import { SyllabusService } from '../../services/syllabus.service';
 
 @Component({
   selector: 'app-chapter-tracker-page',
@@ -9,13 +11,23 @@ import { ChipComponent } from '../../components/chip/chip';
   templateUrl: './chapter-tracker-page.html',
   styleUrl: './chapter-tracker-page.scss'
 })
-export class ChapterTrackerPageComponent {
+export class ChapterTrackerPageComponent implements OnInit {
+  chapters: any[] = [];
+  subject = '';
+  constructor(private appState: AppStateService, private syllabusService: SyllabusService) {
+    this.subject = this.appState.getSubject();
+  }
 
-  chapters = [
-    { id: 1, name: 'Chapter 1', status: 'pending', confidence: 0 },
-    { id: 2, name: 'Chapter 2', status: 'in-progress', confidence: 50 },
-    { id: 3, name: 'Chapter 3', status: 'done', confidence: 80 }
-  ];
+  ngOnInit(): void {
+    this.syllabusService.getSyllabusTree().subscribe(data => {
+      const board = this.appState.getBoard();
+      const standard = this.appState.getStandard();
+      const subject = this.appState.getSubject();
+      if (data && data[board] && data[board][standard] && data[board][standard][subject]) {
+        this.chapters = data[board][standard][subject];
+      }
+    });
+  }
 
   get completedCount(): number {
     return this.chapters.filter(c => c.status === 'done').length;

--- a/Orynth/src/app/pages/dashboard/dashboard-page.ts
+++ b/Orynth/src/app/pages/dashboard/dashboard-page.ts
@@ -1,7 +1,9 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { SubjectProgressRingComponent } from '../../components/subject-progress-ring/subject-progress-ring';
 import { ButtonComponent } from '../../components/button/button';
+import { AppStateService } from '../../services/app-state.service';
+import { SyllabusService } from '../../services/syllabus.service';
 
 @Component({
   selector: 'app-dashboard-page',
@@ -9,10 +11,17 @@ import { ButtonComponent } from '../../components/button/button';
   templateUrl: './dashboard-page.html',
   styleUrl: './dashboard-page.scss'
 })
-export class DashboardPageComponent {
+export class DashboardPageComponent implements OnInit {
 
   summary = {
-    subject: 'Math',
-    progress: 68
+    subject: '',
+    progress: 0
   };
+
+  constructor(private appState: AppStateService, private syllabusService: SyllabusService) {}
+
+  ngOnInit(): void {
+    this.summary.subject = this.appState.getSubject();
+    // Additional stats can be calculated using syllabusService if needed.
+  }
 }

--- a/Orynth/src/app/pages/subject-list/subject-list-page.html
+++ b/Orynth/src/app/pages/subject-list/subject-list-page.html
@@ -19,7 +19,7 @@
       </div>
 
       <div class="space-y-4">
-        <button *ngFor="let s of subjects; index as i" routerLink="/chapter-tracker" class="w-full bg-white rounded-xl p-4 card-shadow hover:card-shadow-hover transition-all tap-highlight animate-fade-in" [style.animationDelay]="(i * 0.1) + 's'">
+        <button *ngFor="let s of subjects; index as i" (click)="openSubject(s.name)" class="w-full bg-white rounded-xl p-4 card-shadow hover:card-shadow-hover transition-all tap-highlight animate-fade-in" [style.animationDelay]="(i * 0.1) + 's'">
           <div class="flex items-center space-x-4">
             <div class="w-12 h-12 bg-blue-500 rounded-xl flex items-center justify-center">
               <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" class="w-6 h-6 text-white">

--- a/Orynth/src/app/pages/subject-list/subject-list-page.ts
+++ b/Orynth/src/app/pages/subject-list/subject-list-page.ts
@@ -1,8 +1,10 @@
-import { Component } from '@angular/core';
-import { RouterModule } from '@angular/router';
+import { Component, OnInit } from '@angular/core';
+import { RouterModule, Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { CardComponent } from '../../components/card/card';
 import { ProgressBarComponent } from '../../components/progress-bar/progress-bar';
+import { SyllabusService } from '../../services/syllabus.service';
+import { AppStateService } from '../../services/app-state.service';
 
 @Component({
   selector: 'app-subject-list-page',
@@ -10,11 +12,24 @@ import { ProgressBarComponent } from '../../components/progress-bar/progress-bar
   templateUrl: './subject-list-page.html',
   styleUrl: './subject-list-page.scss'
 })
-export class SubjectListPageComponent {
+export class SubjectListPageComponent implements OnInit {
 
-  subjects = [
-    { id: 1, name: 'Math', progress: 68 },
-    { id: 2, name: 'Science', progress: 45 },
-    { id: 3, name: 'History', progress: 20 }
-  ];
+  subjects: any[] = [];
+
+  constructor(private syllabusService: SyllabusService, private appState: AppStateService, private router: Router) {}
+
+  ngOnInit(): void {
+    this.syllabusService.getSyllabusTree().subscribe(data => {
+      const board = this.appState.getBoard();
+      const standard = this.appState.getStandard();
+      if (data && data[board] && data[board][standard]) {
+        this.subjects = Object.keys(data[board][standard]).map(key => ({ id: key, name: key, progress: 0 }));
+      }
+    });
+  }
+
+  openSubject(name: string) {
+    this.appState.setSubject(name);
+    this.router.navigate(['/chapter-tracker']);
+  }
 }

--- a/Orynth/src/app/services/app-state.service.ts
+++ b/Orynth/src/app/services/app-state.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class AppStateService {
+  private board = '';
+  private standard = '';
+  private subject = '';
+
+  setBoard(value: string) {
+    this.board = value;
+  }
+
+  getBoard(): string {
+    return this.board;
+  }
+
+  setStandard(value: string) {
+    this.standard = value;
+  }
+
+  getStandard(): string {
+    return this.standard;
+  }
+
+  setSubject(value: string) {
+    this.subject = value;
+  }
+
+  getSubject(): string {
+    return this.subject;
+  }
+}

--- a/Orynth/src/app/services/syllabus.service.ts
+++ b/Orynth/src/app/services/syllabus.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, of } from 'rxjs';
+import { catchError, tap } from 'rxjs/operators';
+
+@Injectable({ providedIn: 'root' })
+export class SyllabusService {
+  private syllabusUrl = 'https://asia-south1-gt-shared-service.cloudfunctions.net/api/syllabus';
+  private cachedSyllabusData: any = null;
+
+  constructor(private http: HttpClient) {}
+
+  getSyllabusTree(): Observable<any> {
+    if (this.cachedSyllabusData) {
+      return of(this.cachedSyllabusData);
+    }
+    return this.http.get(this.syllabusUrl).pipe(
+      tap(data => this.cachedSyllabusData = data),
+      catchError(error => {
+        console.error('Syllabus API error:', error);
+        return of({});
+      })
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add new `SyllabusService` for fetching/caching syllabus tree
- manage selected board/class/subject via `AppStateService`
- hook services into board/class selection, subject list, and chapter tracker pages
- show current subject on chapter tracker and dashboard pages
- provide HttpClient in application config

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68652cd9e150832e9c87d7ae1f5a062b