### PR TITLE
Fetch boards and classes from syllabus API

### DIFF
--- a/Orynth/src/app/pages/board-class-selection/board-class-selection-page.html
+++ b/Orynth/src/app/pages/board-class-selection/board-class-selection-page.html
@@ -20,8 +20,8 @@
           <div class="space-y-4">
             <button *ngFor="let board of boards" (click)="selectedBoard = board.id" class="w-full p-4 rounded-xl text-left transition-all tap-highlight" [ngClass]="selectedBoard === board.id ? 'bg-primary text-white card-shadow-hover' : 'bg-white card-shadow hover:card-shadow-hover'">
               <h3 class="font-semibold text-lg">{{ board.name }}</h3>
-              <p class="text-sm" [ngClass]="selectedBoard === board.id ? 'text-white/80' : 'text-gray-600'">{{ board.description }}</p>
             </button>
+            <p *ngIf="noBoards" class="text-center text-gray-600">No boards found.</p>
           </div>
         </div>
       </ng-container>
@@ -35,13 +35,14 @@
               Class {{ c }}
             </button>
           </div>
+          <p *ngIf="noClasses" class="text-center text-gray-600 mt-4">No classes found.</p>
         </div>
       </ng-template>
     </div>
   </div>
 
   <div class="p-6">
-    <button *ngIf="step === 1" (click)="step = 2" [disabled]="!selectedBoard" class="w-full h-14 text-lg font-semibold bg-primary hover:bg-primary/90 text-white rounded-xl card-shadow hover:card-shadow-hover tap-highlight disabled:opacity-50 disabled:cursor-not-allowed">Continue</button>
+    <button *ngIf="step === 1" (click)="nextStep()" [disabled]="!selectedBoard" class="w-full h-14 text-lg font-semibold bg-primary hover:bg-primary/90 text-white rounded-xl card-shadow hover:card-shadow-hover tap-highlight disabled:opacity-50 disabled:cursor-not-allowed">Continue</button>
     <button *ngIf="step === 2" (click)="startLearning()" [disabled]="!selectedClass" class="w-full h-14 flex items-center justify-center text-lg font-semibold bg-primary hover:bg-primary/90 text-white rounded-xl card-shadow hover:card-shadow-hover tap-highlight disabled:opacity-50 disabled:cursor-not-allowed">Start Learning</button>
   </div>
 </div>

--- a/Orynth/src/app/pages/board-class-selection/board-class-selection-page.spec.ts
+++ b/Orynth/src/app/pages/board-class-selection/board-class-selection-page.spec.ts
@@ -1,0 +1,41 @@
+import { TestBed } from '@angular/core/testing';
+import { BoardClassSelectionPageComponent } from './board-class-selection-page';
+import { SyllabusService } from '../../services/syllabus.service';
+import { AppStateService } from '../../services/app-state.service';
+import { of } from 'rxjs';
+import { SAMPLE_SYLLABUS } from '../../services/sample-syllabus';
+
+describe('BoardClassSelectionPageComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [BoardClassSelectionPageComponent],
+      providers: [
+        { provide: SyllabusService, useValue: { getSyllabusTree: () => of(SAMPLE_SYLLABUS) } },
+        AppStateService
+      ]
+    }).compileComponents();
+  });
+
+  it('should load boards and classes', () => {
+    const fixture = TestBed.createComponent(BoardClassSelectionPageComponent);
+    const component = fixture.componentInstance;
+    fixture.detectChanges();
+    expect(component.boards.length).toBeGreaterThan(0);
+    component.selectedBoard = component.boards[0].id;
+    component.nextStep();
+    expect(component.classes.length).toBeGreaterThan(0);
+  });
+
+  it('should show messages when no data', () => {
+    TestBed.overrideProvider(SyllabusService, { useValue: { getSyllabusTree: () => of({}) } });
+    const fixture = TestBed.createComponent(BoardClassSelectionPageComponent);
+    fixture.detectChanges();
+    const component = fixture.componentInstance;
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('No boards found');
+    component.selectedBoard = 'CBSE';
+    component.nextStep();
+    fixture.detectChanges();
+    expect(compiled.textContent).toContain('No classes found');
+  });
+});

--- a/Orynth/src/app/pages/board-class-selection/board-class-selection-page.ts
+++ b/Orynth/src/app/pages/board-class-selection/board-class-selection-page.ts
@@ -1,25 +1,43 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule, Router } from '@angular/router';
 import { AppStateService } from '../../services/app-state.service';
+import { SyllabusService } from '../../services/syllabus.service';
 
 @Component({
   selector: 'app-board-class-selection-page',
   imports: [CommonModule, RouterModule],
   templateUrl: './board-class-selection-page.html'
 })
-export class BoardClassSelectionPageComponent {
+export class BoardClassSelectionPageComponent implements OnInit {
   step: 1 | 2 = 1;
   selectedBoard = '';
   selectedClass = '';
-  boards = [
-    { id: 'cbse', name: 'CBSE', description: 'Central Board of Secondary Education' },
-    { id: 'icse', name: 'ICSE', description: 'Indian Certificate of Secondary Education' },
-    { id: 'state', name: 'State Board', description: 'State Government Board' }
-  ];
-  classes = ['6', '7', '8', '9', '10', '11', '12'];
+  boards: { id: string; name: string; description?: string }[] = [];
+  classes: string[] = [];
+  noBoards = false;
+  noClasses = false;
+  private syllabus: any = {};
 
-  constructor(private router: Router, private appState: AppStateService) {}
+  constructor(
+    private router: Router,
+    private appState: AppStateService,
+    private syllabusService: SyllabusService
+  ) {}
+
+  ngOnInit(): void {
+    this.syllabusService.getSyllabusTree().subscribe(data => {
+      this.syllabus = data || {};
+      this.boards = Object.keys(this.syllabus).map(id => ({ id, name: id }));
+      this.noBoards = this.boards.length === 0;
+    });
+  }
+
+  nextStep() {
+    this.step = 2;
+    this.classes = Object.keys(this.syllabus[this.selectedBoard] || {});
+    this.noClasses = this.classes.length === 0;
+  }
 
   startLearning() {
     this.appState.setBoard(this.selectedBoard);

--- a/Orynth/src/app/pages/chapter-tracker/chapter-tracker-page.html
+++ b/Orynth/src/app/pages/chapter-tracker/chapter-tracker-page.html
@@ -42,6 +42,7 @@
             </div>
           </div>
         </div>
+        <p *ngIf="noData" class="text-center text-gray-600">No chapters found.</p>
       </div>
 
       <div class="mt-8 text-center animate-fade-in" style="animation-delay: 0.4s">

--- a/Orynth/src/app/pages/chapter-tracker/chapter-tracker-page.spec.ts
+++ b/Orynth/src/app/pages/chapter-tracker/chapter-tracker-page.spec.ts
@@ -1,0 +1,34 @@
+import { TestBed } from '@angular/core/testing';
+import { ChapterTrackerPageComponent } from './chapter-tracker-page';
+import { SyllabusService } from '../../services/syllabus.service';
+import { AppStateService } from '../../services/app-state.service';
+import { of } from 'rxjs';
+import { SAMPLE_SYLLABUS } from '../../services/sample-syllabus';
+
+describe('ChapterTrackerPageComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ChapterTrackerPageComponent],
+      providers: [
+        { provide: SyllabusService, useValue: { getSyllabusTree: () => of(SAMPLE_SYLLABUS) } },
+        { provide: AppStateService, useValue: { getBoard: () => 'CBSE', getStandard: () => '5', getSubject: () => 'Maths' } }
+      ]
+    }).compileComponents();
+  });
+
+  it('should load chapters for subject', () => {
+    const fixture = TestBed.createComponent(ChapterTrackerPageComponent);
+    fixture.detectChanges();
+    const component = fixture.componentInstance;
+    expect(component.chapters.length).toBeGreaterThan(0);
+    expect(component.chapters[0].name).toBeDefined();
+  });
+
+  it('should show message when no chapters', () => {
+    TestBed.overrideProvider(SyllabusService, { useValue: { getSyllabusTree: () => of({}) } });
+    const fixture = TestBed.createComponent(ChapterTrackerPageComponent);
+    fixture.detectChanges();
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('No chapters found');
+  });
+});

--- a/Orynth/src/app/pages/chapter-tracker/chapter-tracker-page.ts
+++ b/Orynth/src/app/pages/chapter-tracker/chapter-tracker-page.ts
@@ -14,6 +14,7 @@ import { SyllabusService } from '../../services/syllabus.service';
 export class ChapterTrackerPageComponent implements OnInit {
   chapters: any[] = [];
   subject = '';
+  noData = false;
   constructor(private appState: AppStateService, private syllabusService: SyllabusService) {
     this.subject = this.appState.getSubject();
   }
@@ -24,8 +25,20 @@ export class ChapterTrackerPageComponent implements OnInit {
       const standard = this.appState.getStandard();
       const subject = this.appState.getSubject();
       if (data && data[board] && data[board][standard] && data[board][standard][subject]) {
-        this.chapters = data[board][standard][subject];
+        const chaptersData = data[board][standard][subject];
+        if (Array.isArray(chaptersData)) {
+          if (chaptersData.length > 0 && typeof chaptersData[0] === 'string') {
+            this.chapters = chaptersData.map((name: string, i: number) => ({ id: i, name, status: 'pending', confidence: 0 }));
+          } else {
+            this.chapters = chaptersData;
+          }
+        } else {
+          this.chapters = [];
+        }
+      } else {
+        this.chapters = [];
       }
+      this.noData = this.chapters.length === 0;
     });
   }
 

--- a/Orynth/src/app/pages/subject-list/subject-list-page.html
+++ b/Orynth/src/app/pages/subject-list/subject-list-page.html
@@ -39,6 +39,7 @@
           </div>
         </button>
       </div>
+      <p *ngIf="noData" class="text-center text-gray-600 mt-4">No subjects found.</p>
 
       <div class="mt-8 bg-white rounded-xl p-4 card-shadow animate-fade-in" style="animation-delay: 0.6s">
         <h3 class="font-semibold text-gray-900 mb-3">Quick Stats</h3>

--- a/Orynth/src/app/pages/subject-list/subject-list-page.spec.ts
+++ b/Orynth/src/app/pages/subject-list/subject-list-page.spec.ts
@@ -1,0 +1,35 @@
+import { TestBed } from '@angular/core/testing';
+import { SubjectListPageComponent } from './subject-list-page';
+import { SyllabusService } from '../../services/syllabus.service';
+import { AppStateService } from '../../services/app-state.service';
+import { of } from 'rxjs';
+import { SAMPLE_SYLLABUS } from '../../services/sample-syllabus';
+
+describe('SubjectListPageComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SubjectListPageComponent],
+      providers: [
+        { provide: SyllabusService, useValue: { getSyllabusTree: () => of(SAMPLE_SYLLABUS) } },
+        { provide: AppStateService, useValue: { getBoard: () => 'CBSE', getStandard: () => '5', setSubject: () => {} } }
+      ]
+    }).compileComponents();
+  });
+
+  it('should load subjects for board and class', () => {
+    const fixture = TestBed.createComponent(SubjectListPageComponent);
+    fixture.detectChanges();
+    const component = fixture.componentInstance;
+    expect(component.subjects.length).toBeGreaterThan(0);
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('Maths');
+  });
+
+  it('should show message when no subjects', async () => {
+    TestBed.overrideProvider(SyllabusService, { useValue: { getSyllabusTree: () => of({}) } });
+    const fixture = TestBed.createComponent(SubjectListPageComponent);
+    fixture.detectChanges();
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('No subjects found');
+  });
+});

--- a/Orynth/src/app/pages/subject-list/subject-list-page.ts
+++ b/Orynth/src/app/pages/subject-list/subject-list-page.ts
@@ -15,6 +15,7 @@ import { AppStateService } from '../../services/app-state.service';
 export class SubjectListPageComponent implements OnInit {
 
   subjects: any[] = [];
+  noData = false;
 
   constructor(private syllabusService: SyllabusService, private appState: AppStateService, private router: Router) {}
 
@@ -24,7 +25,10 @@ export class SubjectListPageComponent implements OnInit {
       const standard = this.appState.getStandard();
       if (data && data[board] && data[board][standard]) {
         this.subjects = Object.keys(data[board][standard]).map(key => ({ id: key, name: key, progress: 0 }));
+      } else {
+        this.subjects = [];
       }
+      this.noData = this.subjects.length === 0;
     });
   }
 

--- a/Orynth/src/app/services/sample-syllabus.ts
+++ b/Orynth/src/app/services/sample-syllabus.ts
@@ -1,0 +1,499 @@
+export const SAMPLE_SYLLABUS = {
+  "CBSE": {
+    "5": {
+      "Maths": [
+        "Large Numbers",
+        "Profit and Loss",
+        "Measurement of Length, Mass and Capacity",
+        "Conceptual",
+        "Data Handling",
+        "Logical Reasoning",
+        "Area",
+        "Factors and Multiples",
+        "Volume, Perimeter and Area",
+        "Lines, Angles & Triangles",
+        "Money",
+        "Volume",
+        "Simplification",
+        "Symmetry and Nets",
+        "Rounding of Numbers",
+        "Simplification",
+        "Fractions",
+        "Circles",
+        "Measurement of Length, Mass and Capacity",
+        "Large Numbers",
+        "Lines, Angles & Triangles",
+        "Patterns",
+        "HCF & LCM",
+        "Decimals",
+        "Integers",
+        "Ratio And Proportion",
+        "Perimeter and Area",
+        "Time and Temperature",
+        "Rounding of Numbers",
+        "Percentages",
+        "Rounding of Numbers"
+      ],
+      "Science": [
+        "Food, Nutrition, Health and Nutrition",
+        "Skeletal and Muscular System",
+        "Animal Life",
+        "Force and Machines",
+        "Nervous System",
+        "Plant Life"
+      ]
+    },
+    "6": {
+      "Geography": [
+        "Motions of the Earth",
+        "The Earth in the Solar System",
+        "Globe Latitudes and Longitudes",
+        "Globe Latitudes and Longitudes"
+      ],
+      "Maths": [
+        "Integers"
+      ],
+      "English": [
+        "Spell Check",
+        "Spell Check"
+      ]
+    },
+    "7": {
+      "Maths": [
+        "Fractions and Decimals",
+        "Fractions and Decimals",
+        "Perimeter and Area",
+        "Rational Numbers",
+        "The Triangles and its Properties",
+        "Integers",
+        "Algebraic Expression",
+        "Fractions",
+        "Integers",
+        "Exponent and Power",
+        "Lines and Angles",
+        "Integers",
+        "Algebraic Expression",
+        "Visualizing Solid Shapes",
+        "Symmetry",
+        "Lines and Angles",
+        "Integers",
+        "Integers",
+        "Data Handling",
+        "Rational Numbers",
+        "Simple Equations",
+        "Visualising Solid Shapes",
+        "Integers",
+        "Simple Equations",
+        "The Triangles and Its Properties",
+        "Simple Equations",
+        "The Triangles and it's Properties",
+        "Comparing Quantities",
+        "Integers",
+        "Fractions",
+        "Simple Equations"
+      ],
+      "Science": [
+        "Acid Bases and Salts",
+        "Motion and Time ",
+        "Heat",
+        "Wastewater Story",
+        "Nutrition in Plants",
+        "Transportation in Animals & Plants",
+        "Respiration in Organism",
+        "Nutrition in Animals",
+        "Light",
+        "Reproduction in Plants",
+        "Physical & Chemical Changes",
+        "Electric Current and Its Effects",
+        "Forests-Our Life"
+      ]
+    },
+    "8": {
+      "Maths": [
+        "Practical Geometry",
+        "Linear Equations in One Variable",
+        "Factorisation",
+        "Algebraic Expressions and Identities",
+        "Algebraic Expressions and Identities",
+        "Speed, Distance, Time",
+        "Factorisation",
+        "Linear Equations in One Variable",
+        "Data Handling",
+        "Factorisation",
+        "Visualising Solid Shapes",
+        "Cubes and Cube Roots",
+        "Introduction to graphs",
+        "Algebraic Expressions and Identities",
+        "Rational Numbers",
+        "Data Handling",
+        "Algebraic Expressions and Identities",
+        "Practical Geometry",
+        "Mensuration",
+        "Rational Numbers",
+        "Rational Numbers",
+        "Exponents and Powers",
+        "Cubes and Cube Roots",
+        "Cubes and Cube Roots",
+        "Playing with Numbers",
+        "Exponents and Powers",
+        "Rational Numbers",
+        "Data Handling",
+        "Data Handling",
+        "Direct and Inverse Proportions",
+        "Rational Numbers",
+        "Data Handling",
+        "Cubes and Cube Roots",
+        "Direct and Inverse Proportions",
+        "Rational Numbers",
+        "Rational Numbers",
+        "Cubes and Cube Roots",
+        "Comparing Quantities",
+        "Data Handling",
+        "Polynomials",
+        "Understanding Quadrilaterals",
+        "Exponents and Powers",
+        "Exponents and Powers",
+        "Squares and Square Roots",
+        "Exponents Powers"
+      ],
+      "Science": [
+        "Crop Production and Management",
+        "Crop Production and Management",
+        "Crop Production and Management",
+        "Synthetic Fibres and Plastics",
+        "Friction",
+        "Crop Production and Management",
+        "Crop Production and Management",
+        "Crop Production and Management",
+        "Weed Control and Management",
+        "Chemical Reactions",
+        "Crop Production and Management",
+        "Microorganisms: Friend and Foe",
+        "Force and Pressure",
+        "Crop Production and Management",
+        "Crop Production and Management",
+        "Crop Production and Management",
+        "Crop Production and Management",
+        "Crop Production and Management",
+        "Crop Production and Management",
+        "Materials: Metals and Non-Metals",
+        "Crop Production and Management",
+        "Crop Production and Management",
+        "Crop Production and Management",
+        "Crop Production and Management",
+        "Crop Production and Management"
+      ],
+      "SST": [
+        "Economic Activities in your Area",
+        "Minerals and It's Resources"
+      ],
+      "History": [
+        "How, When and Where"
+      ],
+      "Geography": [
+        "Resources"
+      ]
+    },
+    "9": {
+      "Maths": [
+        "Number Systems",
+        "Polynomials"
+      ]
+    },
+    "10": {
+      "Physics": [
+        "Mechanical Properties of Fluids",
+        "Thermal Properties of Matter",
+        "Current Electricity",
+        "Properties of Bulk Matter",
+        "Motion in a Straight Line",
+        "Work, Energy and Power",
+        "Oscillations",
+        "Motion in a Plane",
+        "Optics"
+      ],
+      "Science": [
+        "Carbon and its Compounds",
+        "Light Reflection and Refraction",
+        "Acids, Bases, and Salts",
+        "Metals and Non Metals",
+        "Acids, Bases and Salts",
+        "Life Processes",
+        "Pest Management",
+        "Periodic Classification of Elements",
+        "Chemical Reactions and Equation",
+        "Cell - Basic Unit of Life",
+        "Metals and Non Metals",
+        "Chemical Reactions and Equations",
+        "Carbon and its Compounds"
+      ],
+      "Maths": [
+        "Exponents and Powers",
+        "Quadratic Equations",
+        "Visualising Solid Shapes",
+        "Factorisation",
+        "Real Numbers",
+        "Algebra",
+        "Arithmetic Progressions ",
+        "Pair of Linear Equations in Two Variables",
+        "Polynomials",
+        "Arithmetic Progressions",
+        "Mensuration",
+        "Trigonometry",
+        "Algebraic Expressions and Identities",
+        "Trigonometry"
+      ],
+      "History": [
+        "The Nationalist Movement in Indo-China",
+        "Nationalism in India",
+        "The Rise of Nationalism in Europe"
+      ],
+      "English": [
+        "General Puzzles"
+      ],
+      "Civics": [
+        "Power Sharing"
+      ],
+      "Geography": [
+        "Resource and Development"
+      ]
+    },
+    "11": {
+      "Physics": [
+        "Properties of Bulk Matter",
+        "Motion in a Straight Line",
+        "Current Electricity",
+        "Work, Energy and Power",
+        "Oscillations",
+        "Properties of Bulk Matter",
+        "Mechanical Properties of Fluids",
+        "Motion in a Plane",
+        "Work, Energy and Power",
+        "Current Electricity",
+        "Units and Measurements",
+        "Oscillations",
+        "Optics",
+        "Mechanical Properties of Fluids",
+        "Motion in a Plane",
+        "Motion in a Straight Line",
+        "Optics",
+        "Thermal Properties of Matter"
+      ],
+      "Biology": [
+        "Crop Production and Management",
+        "The Living World",
+        "The Living World",
+        "Pest Management"
+      ],
+      "Maths": [
+        "Speed, Distance, Time",
+        "Set"
+      ]
+    },
+    "12": {
+      "Maths": [
+        "Inverse Trigonometric Functions",
+        "Relations and Functions",
+        "Inverse Trigonmetric Functions"
+      ],
+      "Physics": [
+        "Thermal Properties of Matter"
+      ],
+      "Biology": [
+        "Pest Management"
+      ]
+    }
+  },
+  "ICSE": {
+    "6": {
+      "English": [
+        "Spell Check",
+        "English Grammer",
+        "Reading",
+        "English Grammar",
+        "Spell Check",
+        "Spell Check",
+        "Writing",
+        "Spell Check",
+        "Story",
+        "Listening and Speaking"
+      ],
+      "Maths": [
+        "Roman Numerals",
+        "Decimals",
+        "Sets",
+        "Integers",
+        "Fractions",
+        "Basic Geometrical Ideas",
+        "Knowing our Numbers",
+        "Whole Numbers",
+        "Data Handling",
+        "Understanding Elementary Shapes",
+        "Playing with Numbers",
+        "Practical Geometry",
+        "Algebra",
+        "Ratio and Proportion",
+        "Fraction",
+        "Basic Geometrical Ideas",
+        "Knowing our Number",
+        "Whole Numbers",
+        "Basic Geometrical Ideas",
+        "Mensuration",
+        "Understanding Symmetrical Shapes",
+        "Roman Numerals",
+        "Integers",
+        "Symmetry",
+        "Playing with Numbers"
+      ],
+      "Science": [
+        "Circulatory System",
+        "Light",
+        "Energy",
+        "Physical Quantities and Measurement",
+        "Adaptation",
+        "Magnetism",
+        "Health and Hygiene",
+        "Introduction to Chemical Elements",
+        "Digestive System",
+        "Matter",
+        "Human Body",
+        "Water",
+        "Electricity",
+        "Plant Life",
+        "Air and Atmosphere",
+        "Matter",
+        "The Cell",
+        "Respiratory System",
+        "Force",
+        "Elements, Compounds and Mixtures",
+        "Magnet",
+        "Introduction to Chemistry"
+      ],
+      "Computer": [
+        "Word Processor – Tabular Presentation",
+        "Internet – Online Surfing",
+        "Presentation – Visual Effects",
+        "Scratch Programming – Introduction to Game Creation",
+        "Word Processor – Mail Merge",
+        "Categories of Computers and Computer Languages",
+        "HTML – An Introduction",
+        "File Management – Organisation of Data"
+      ],
+      "Geography": [
+        "Study of Continents: North America and South America",
+        "Representation of Geographical Features",
+        "Minerals",
+        "Landforms",
+        "Water Bodies",
+        "Agriculture"
+      ],
+      "History": [
+        "The Golden Age – Gupta Empire",
+        "The Mauryan Empire",
+        "The River Valley Civilizations",
+        "The Vedic Civilization",
+        "Rise of Kingdoms & Republicans",
+        "Mahavira & Buddha – Great Preachers"
+      ],
+      "Civics": [
+        "The Rural Local Self Government",
+        "Urban Local Self Government"
+      ]
+    },
+    "7": {
+      "Maths": [
+        "Data Handling",
+        "Integers"
+      ]
+    },
+    "8": {
+      "English": [
+        "Spell Check"
+      ],
+      "Maths": [
+        "Direct and Inverse Proportions",
+        "Factorisation",
+        "Rational Numbers",
+        "Exponents Powers"
+      ],
+      "Science": [
+        "Transport of Food and Minerals in Plants"
+      ]
+    },
+    "10": {
+      "Science": [
+        "Periodic Properties and Variations of Properties – Physical and Chemical",
+        "Chemical Bonding",
+        "Genetics",
+        "Study of Compounds",
+        "Organic Chemistry",
+        "Mole Concept and Stoichiometry",
+        "Analytical Chemistry",
+        "Light",
+        "Comparison of Metallic and Non-Metallic Nature in Different Periods and Groups",
+        "Comparison of Physical and Chemical Properties within a Period",
+        "Basic Biology",
+        "Atomic and Ionic Radii of Transition and Inner Transition Elements",
+        "Sound",
+        "Comparison of Physical and Chemical Properties within a Period",
+        "Periodic Properties and Variations of Properties – Physical and Chemical",
+        "Basic Biology",
+        "Metallurgy",
+        "Force, Work, Power and Energy",
+        "Electricity and Magnetism",
+        "Periodic Properties and Variations of Properties – Physical and Chemical",
+        "Study of Acids, Bases and Salts",
+        "Allotropy",
+        "Comparison of Physical and Chemical Properties within a Group",
+        "Comparison of Physical and Chemical Properties within a Period",
+        "Modern Physics",
+        "Covalent Bonding",
+        "Covelent Bonding",
+        "Structure of Chromosomes",
+        "Heat",
+        "Periodic properties and their variations in groups and periods",
+        "Mole Concept and Stoichiometry",
+        "Basic Biology",
+        "Periodic properties and their variations in groups and periods.",
+        "Electrolysis",
+        "Electron Gain Enthalpy Trends and Their Explanation"
+      ],
+      "Maths": [
+        "Arithmetic and Geometric Progression",
+        "Circles",
+        "GST",
+        "Linear Equation in One Variable",
+        "Circles",
+        "Probability",
+        "Factorisation of polynomial",
+        "Circles",
+        "Trigonometry",
+        "Ratio and Proportion",
+        "Quadratic Equations in one variable",
+        "Similarity",
+        "Banking",
+        "Linear Inequations",
+        "Co-ordinate Geometry",
+        "Matrices",
+        "Linear Equation in One Variable",
+        "Constructions",
+        "Mensuration",
+        "Statistics",
+        "Shares and Dividends",
+        "Circles",
+        "Loci",
+        "Trigonometry"
+      ]
+    },
+    "11": {
+      "Maths": [
+        "angles-and-arc-lengths"
+      ]
+    },
+    "All": {
+      "Maths": [
+        "Speed, Distance, Time"
+      ]
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- load available boards and classes from the syllabus service
- show 'No boards/classes found' messages when appropriate
- test board/class page with sample syllabus

## Testing
- `npm run build`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_68653c94fe0c832e9781e69f1ae7de75