### PR TITLE
Implement chapter progress toggling

### DIFF
--- a/Orynth/src/app/pages/chapter-tracker/chapter-tracker-page.html
+++ b/Orynth/src/app/pages/chapter-tracker/chapter-tracker-page.html
@@ -34,7 +34,12 @@
           <div class="flex items-center justify-between">
             <div class="flex items-center space-x-3">
               <div class="text-xs text-gray-500 mb-1">Status</div>
-              <app-chip [label]="c.status" [color]="c.status"></app-chip>
+              <app-chip
+                class="cursor-pointer"
+                (click)="cycleStatus(c)"
+                [label]="getStatusLabel(c.status)"
+                [color]="c.status"
+              ></app-chip>
             </div>
             <div class="flex items-center space-x-3">
               <div class="text-xs text-gray-500 mb-1">Confidence</div>

--- a/Orynth/src/app/pages/chapter-tracker/chapter-tracker-page.ts
+++ b/Orynth/src/app/pages/chapter-tracker/chapter-tracker-page.ts
@@ -38,8 +38,39 @@ export class ChapterTrackerPageComponent implements OnInit {
       } else {
         this.chapters = [];
       }
+
+      const saved = localStorage.getItem(`${subject}-progress`);
+      if (saved) {
+        try {
+          const savedChapters = JSON.parse(saved);
+          this.chapters = this.chapters.map(c => {
+            const match = savedChapters.find((s: any) => s.id === c.id && s.name === c.name);
+            return match ? { ...c, status: match.status, confidence: match.confidence } : c;
+          });
+        } catch {}
+      }
+
       this.noData = this.chapters.length === 0;
     });
+  }
+
+  cycleStatus(chapter: any) {
+    const cycle = ['pending', 'in-progress', 'done'];
+    const idx = cycle.indexOf(chapter.status);
+    chapter.status = cycle[(idx + 1) % cycle.length];
+    this.saveProgress();
+  }
+
+  saveProgress() {
+    localStorage.setItem(`${this.subject}-progress`, JSON.stringify(this.chapters));
+  }
+
+  getStatusLabel(status: string): string {
+    switch (status) {
+      case 'done': return 'Completed';
+      case 'in-progress': return 'In Progress';
+      default: return 'Pending';
+    }
   }
 
   get completedCount(): number {

--- a/Orynth/src/app/pages/subject-list/subject-list-page.ts
+++ b/Orynth/src/app/pages/subject-list/subject-list-page.ts
@@ -24,7 +24,20 @@ export class SubjectListPageComponent implements OnInit {
       const board = this.appState.getBoard();
       const standard = this.appState.getStandard();
       if (data && data[board] && data[board][standard]) {
-        this.subjects = Object.keys(data[board][standard]).map(key => ({ id: key, name: key, progress: 0 }));
+        this.subjects = Object.keys(data[board][standard]).map(key => {
+          const saved = localStorage.getItem(`${key}-progress`);
+          let progress = 0;
+          if (saved) {
+            try {
+              const chapters = JSON.parse(saved);
+              if (chapters.length) {
+                const completed = chapters.filter((c: any) => c.status === 'done').length;
+                progress = Math.round((completed / chapters.length) * 100);
+              }
+            } catch {}
+          }
+          return { id: key, name: key, progress };
+        });
       } else {
         this.subjects = [];
       }


### PR DESCRIPTION
## Summary
- toggle chapter status chips on Chapter Tracker page
- persist chapter progress in localStorage
- read progress to compute subject progress in the list view

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68656e044c94832eada94455e7bcca4c