### PR TITLE
Implement dynamic progress stats

### DIFF
--- a/Orynth/src/app/pages/dashboard/dashboard-page.html
+++ b/Orynth/src/app/pages/dashboard/dashboard-page.html
@@ -27,75 +27,18 @@
       <div class="bg-white rounded-xl p-4 card-shadow mb-6 animate-fade-in" style="animation-delay: 0.1s">
         <h3 class="font-semibold text-gray-900 mb-4">Subject Progress</h3>
         <div class="space-y-4">
-          <div class="flex items-center space-x-4">
-            <div class="w-8 h-8 bg-indigo-500 rounded-lg flex-shrink-0"></div>
+          <div *ngFor="let s of subjects" class="flex items-center space-x-4">
+            <div class="w-8 h-8 rounded-lg flex-shrink-0" [ngClass]="s.color"></div>
             <div class="flex-1">
               <div class="flex justify-between items-center mb-1">
-                <span class="text-sm font-medium text-gray-900">English</span>
-                <span class="text-sm text-gray-600">85%</span>
+                <span class="text-sm font-medium text-gray-900">{{ s.name }}</span>
+                <span class="text-sm text-gray-600">{{ s.progress }}%</span>
               </div>
               <div class="bg-gray-200 rounded-full h-2">
-                <div class="h-2 rounded-full transition-all bg-success" style="width: 85%"></div>
-              </div>
-            </div>
-          </div>
-          <div class="flex items-center space-x-4">
-            <div class="w-8 h-8 bg-green-500 rounded-lg flex-shrink-0"></div>
-            <div class="flex-1">
-              <div class="flex justify-between items-center mb-1">
-                <span class="text-sm font-medium text-gray-900">Chemistry</span>
-                <span class="text-sm text-gray-600">72%</span>
-              </div>
-              <div class="bg-gray-200 rounded-full h-2">
-                <div class="h-2 rounded-full transition-all bg-success" style="width: 72%"></div>
-              </div>
-            </div>
-          </div>
-          <div class="flex items-center space-x-4">
-            <div class="w-8 h-8 bg-blue-500 rounded-lg flex-shrink-0"></div>
-            <div class="flex-1">
-              <div class="flex justify-between items-center mb-1">
-                <span class="text-sm font-medium text-gray-900">Mathematics</span>
-                <span class="text-sm text-gray-600">68%</span>
-              </div>
-              <div class="bg-gray-200 rounded-full h-2">
-                <div class="h-2 rounded-full transition-all bg-warning" style="width: 68%"></div>
-              </div>
-            </div>
-          </div>
-          <div class="flex items-center space-x-4">
-            <div class="w-8 h-8 bg-yellow-500 rounded-lg flex-shrink-0"></div>
-            <div class="flex-1">
-              <div class="flex justify-between items-center mb-1">
-                <span class="text-sm font-medium text-gray-900">Social Science</span>
-                <span class="text-sm text-gray-600">56%</span>
-              </div>
-              <div class="bg-gray-200 rounded-full h-2">
-                <div class="h-2 rounded-full transition-all bg-warning" style="width: 56%"></div>
-              </div>
-            </div>
-          </div>
-          <div class="flex items-center space-x-4">
-            <div class="w-8 h-8 bg-purple-500 rounded-lg flex-shrink-0"></div>
-            <div class="flex-1">
-              <div class="flex justify-between items-center mb-1">
-                <span class="text-sm font-medium text-gray-900">Physics</span>
-                <span class="text-sm text-gray-600">45%</span>
-              </div>
-              <div class="bg-gray-200 rounded-full h-2">
-                <div class="h-2 rounded-full transition-all bg-warning" style="width: 45%"></div>
-              </div>
-            </div>
-          </div>
-          <div class="flex items-center space-x-4">
-            <div class="w-8 h-8 bg-red-500 rounded-lg flex-shrink-0"></div>
-            <div class="flex-1">
-              <div class="flex justify-between items-center mb-1">
-                <span class="text-sm font-medium text-gray-900">Biology</span>
-                <span class="text-sm text-gray-600">38%</span>
-              </div>
-              <div class="bg-gray-200 rounded-full h-2">
-                <div class="h-2 rounded-full transition-all bg-pending" style="width: 38%"></div>
+                <div class="h-2 rounded-full transition-all"
+                     [ngClass]="{ 'bg-success': s.progress >= 70, 'bg-warning': s.progress >= 40 && s.progress < 70, 'bg-pending': s.progress < 40 }"
+                     [style.width]="s.progress + '%'">
+                </div>
               </div>
             </div>
           </div>
@@ -103,7 +46,7 @@
       </div>
 
       <div class="space-y-4">
-        <div class="bg-white rounded-xl p-4 card-shadow animate-fade-in" style="animation-delay: 0.2s">
+        <div *ngIf="focusArea" class="bg-white rounded-xl p-4 card-shadow animate-fade-in" style="animation-delay: 0.2s">
           <div class="flex items-start space-x-3">
             <div class="w-10 h-10 bg-warning-light rounded-full flex items-center justify-center flex-shrink-0">
               <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" class="w-5 h-5 text-warning">
@@ -114,12 +57,12 @@
             </div>
             <div>
               <h4 class="font-semibold text-gray-900 mb-1">Focus Area</h4>
-              <p class="text-sm text-gray-600"><span class="font-medium">Biology</span> needs attention. Consider spending more time on this subject.</p>
+              <p class="text-sm text-gray-600"><span class="font-medium">{{ focusArea?.name }}</span> needs attention. Consider spending more time on this subject.</p>
             </div>
           </div>
         </div>
 
-        <div class="bg-white rounded-xl p-4 card-shadow animate-fade-in" style="animation-delay: 0.3s">
+        <div *ngIf="goodSubject" class="bg-white rounded-xl p-4 card-shadow animate-fade-in" style="animation-delay: 0.3s">
           <div class="flex items-start space-x-3">
             <div class="w-10 h-10 bg-success-light rounded-full flex items-center justify-center flex-shrink-0">
               <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" class="w-5 h-5 text-success">
@@ -128,7 +71,7 @@
             </div>
             <div>
               <h4 class="font-semibold text-gray-900 mb-1">Great Progress!</h4>
-              <p class="text-sm text-gray-600">You're doing excellent in <span class="font-medium">English</span>. Keep up the good work!</p>
+              <p class="text-sm text-gray-600">You're doing excellent in <span class="font-medium">{{ goodSubject?.name }}</span>. Keep up the good work!</p>
             </div>
           </div>
         </div>

--- a/Orynth/src/app/pages/dashboard/dashboard-page.ts
+++ b/Orynth/src/app/pages/dashboard/dashboard-page.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { RouterModule } from '@angular/router';
+import { CommonModule } from '@angular/common';
 import { SubjectProgressRingComponent } from '../../components/subject-progress-ring/subject-progress-ring';
 import { ButtonComponent } from '../../components/button/button';
 import { AppStateService } from '../../services/app-state.service';
@@ -7,21 +8,60 @@ import { SyllabusService } from '../../services/syllabus.service';
 
 @Component({
   selector: 'app-dashboard-page',
-  imports: [RouterModule, SubjectProgressRingComponent, ButtonComponent],
+  imports: [CommonModule, RouterModule, SubjectProgressRingComponent, ButtonComponent],
   templateUrl: './dashboard-page.html',
   styleUrl: './dashboard-page.scss'
 })
 export class DashboardPageComponent implements OnInit {
-
   summary = {
     subject: '',
     progress: 0
   };
 
+  subjects: { name: string; progress: number; color: string }[] = [];
+  focusArea: { name: string; progress: number } | null = null;
+  goodSubject: { name: string; progress: number } | null = null;
+  colors = [
+    'bg-indigo-500',
+    'bg-green-500',
+    'bg-blue-500',
+    'bg-yellow-500',
+    'bg-purple-500',
+    'bg-red-500',
+    'bg-pink-500',
+    'bg-teal-500'
+  ];
+
   constructor(private appState: AppStateService, private syllabusService: SyllabusService) {}
 
   ngOnInit(): void {
     this.summary.subject = this.appState.getSubject();
-    // Additional stats can be calculated using syllabusService if needed.
+    const board = this.appState.getBoard();
+    const standard = this.appState.getStandard();
+    this.syllabusService.getSyllabusTree().subscribe(data => {
+      if (data && data[board] && data[board][standard]) {
+        const keys = Object.keys(data[board][standard]);
+        this.subjects = keys.map((name, idx) => {
+          const saved = localStorage.getItem(`${name}-progress`);
+          let progress = 0;
+          if (saved) {
+            try {
+              const chapters = JSON.parse(saved);
+              if (chapters.length) {
+                const completed = chapters.filter((c: any) => c.status === 'done').length;
+                progress = Math.round((completed / chapters.length) * 100);
+              }
+            } catch {}
+          }
+          return { name, progress, color: this.colors[idx % this.colors.length] };
+        });
+        if (this.subjects.length) {
+          const sorted = [...this.subjects].sort((a, b) => a.progress - b.progress);
+          this.focusArea = sorted[0];
+          this.goodSubject = sorted[sorted.length - 1];
+          this.summary.progress = Math.round(this.subjects.reduce((a, c) => a + c.progress, 0) / this.subjects.length);
+        }
+      }
+    });
   }
 }

--- a/Orynth/src/app/pages/subject-list/subject-list-page.html
+++ b/Orynth/src/app/pages/subject-list/subject-list-page.html
@@ -45,11 +45,11 @@
         <h3 class="font-semibold text-gray-900 mb-3">Quick Stats</h3>
         <div class="grid grid-cols-2 gap-4">
           <div class="text-center">
-            <div class="text-2xl font-bold text-primary mb-1">4</div>
+            <div class="text-2xl font-bold text-primary mb-1">{{ startedCount }}</div>
             <div class="text-sm text-gray-600">Subjects Started</div>
           </div>
           <div class="text-center">
-            <div class="text-2xl font-bold text-success mb-1">62%</div>
+            <div class="text-2xl font-bold text-success mb-1">{{ overallProgress }}%</div>
             <div class="text-sm text-gray-600">Overall Progress</div>
           </div>
         </div>

--- a/Orynth/src/app/pages/subject-list/subject-list-page.ts
+++ b/Orynth/src/app/pages/subject-list/subject-list-page.ts
@@ -1,14 +1,12 @@
 import { Component, OnInit } from '@angular/core';
 import { RouterModule, Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
-import { CardComponent } from '../../components/card/card';
-import { ProgressBarComponent } from '../../components/progress-bar/progress-bar';
 import { SyllabusService } from '../../services/syllabus.service';
 import { AppStateService } from '../../services/app-state.service';
 
 @Component({
   selector: 'app-subject-list-page',
-  imports: [CommonModule, RouterModule, CardComponent, ProgressBarComponent],
+  imports: [CommonModule, RouterModule],
   templateUrl: './subject-list-page.html',
   styleUrl: './subject-list-page.scss'
 })
@@ -16,6 +14,8 @@ export class SubjectListPageComponent implements OnInit {
 
   subjects: any[] = [];
   noData = false;
+  startedCount = 0;
+  overallProgress = 0;
 
   constructor(private syllabusService: SyllabusService, private appState: AppStateService, private router: Router) {}
 
@@ -42,6 +42,10 @@ export class SubjectListPageComponent implements OnInit {
         this.subjects = [];
       }
       this.noData = this.subjects.length === 0;
+      this.startedCount = this.subjects.filter(s => s.progress > 0).length;
+      this.overallProgress = this.subjects.length === 0
+        ? 0
+        : Math.round(this.subjects.reduce((acc, cur) => acc + cur.progress, 0) / this.subjects.length);
     });
   }
 


### PR DESCRIPTION
## Summary
- compute quick stat values from saved chapter progress
- show real data on dashboard with focus and good performing subjects
- color-code each subject's progress bar and track average

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6865833184b4832e85f753bdd9dd095d