### PR TITLE
Add profile page and unsynced banner

### DIFF
--- a/Orynth/src/app/app.routes.ts
+++ b/Orynth/src/app/app.routes.ts
@@ -1,4 +1,5 @@
 import { Routes } from '@angular/router';
+import { ProfilePageComponent } from './pages/profile-page/profile-page';
 
 export const routes: Routes = [
   { path: '', redirectTo: 'onboarding', pathMatch: 'full' },
@@ -21,5 +22,10 @@ export const routes: Routes = [
   {
     path: 'dashboard',
     loadComponent: () => import('./pages/dashboard/dashboard-page').then(m => m.DashboardPageComponent)
+  },
+  {
+    path: 'profile',
+    component: ProfilePageComponent,
+    title: 'Profile'
   },
 ];

--- a/Orynth/src/app/components/unsynced-notice/unsynced-notice.html
+++ b/Orynth/src/app/components/unsynced-notice/unsynced-notice.html
@@ -1,0 +1,4 @@
+<div *ngIf="show" class="bg-warning-light text-warning text-sm text-center p-3">
+  You’re using a temporary account. Sign in to save your progress across devices.
+  <button class="ml-2 text-warning underline" disabled hidden>Sign In Now</button>
+</div>

--- a/Orynth/src/app/components/unsynced-notice/unsynced-notice.scss
+++ b/Orynth/src/app/components/unsynced-notice/unsynced-notice.scss
@@ -1,0 +1,1 @@
+:host { display: block; }

--- a/Orynth/src/app/components/unsynced-notice/unsynced-notice.ts
+++ b/Orynth/src/app/components/unsynced-notice/unsynced-notice.ts
@@ -1,0 +1,20 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Auth } from '@angular/fire/auth';
+import { AuthService } from '../../services/auth.service';
+
+@Component({
+  selector: 'app-unsynced-notice',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './unsynced-notice.html',
+  styleUrl: './unsynced-notice.scss'
+})
+export class UnsyncedNoticeComponent {
+  show = false;
+  constructor(private auth: Auth, private authService: AuthService) {
+    this.authService.authState$.subscribe(u => {
+      this.show = !!u && u.isAnonymous;
+    });
+  }
+}

--- a/Orynth/src/app/pages/board-class-selection/board-class-selection-page.html
+++ b/Orynth/src/app/pages/board-class-selection/board-class-selection-page.html
@@ -1,4 +1,5 @@
 <div class="min-h-screen bg-gradient-to-br from-blue-50 to-green-50 flex flex-col">
+  <app-unsynced-notice></app-unsynced-notice>
   <div class="flex items-center justify-between p-4">
     <button (click)="step === 1 ? goHome() : step = 1" class="p-2 hover:bg-white/20 rounded-full tap-highlight">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-6 h-6 text-gray-700">

--- a/Orynth/src/app/pages/board-class-selection/board-class-selection-page.ts
+++ b/Orynth/src/app/pages/board-class-selection/board-class-selection-page.ts
@@ -3,10 +3,11 @@ import { CommonModule } from '@angular/common';
 import { RouterModule, Router } from '@angular/router';
 import { AppStateService } from '../../services/app-state.service';
 import { SyllabusService } from '../../services/syllabus.service';
+import { UnsyncedNoticeComponent } from '../../components/unsynced-notice/unsynced-notice';
 
 @Component({
   selector: 'app-board-class-selection-page',
-  imports: [CommonModule, RouterModule],
+  imports: [CommonModule, RouterModule, UnsyncedNoticeComponent],
   templateUrl: './board-class-selection-page.html'
 })
 export class BoardClassSelectionPageComponent implements OnInit {

--- a/Orynth/src/app/pages/chapter-tracker/chapter-tracker-page.html
+++ b/Orynth/src/app/pages/chapter-tracker/chapter-tracker-page.html
@@ -1,4 +1,5 @@
 <div class="min-h-screen bg-gradient-to-br from-blue-50 to-green-50">
+  <app-unsynced-notice></app-unsynced-notice>
   <div class="bg-white/90 backdrop-blur-sm sticky top-0 z-10 border-b border-gray-200">
     <div class="flex items-center justify-between p-4">
       <a routerLink="/subject-list" class="p-2 hover:bg-gray-100 rounded-full tap-highlight">

--- a/Orynth/src/app/pages/chapter-tracker/chapter-tracker-page.ts
+++ b/Orynth/src/app/pages/chapter-tracker/chapter-tracker-page.ts
@@ -4,10 +4,11 @@ import { CommonModule } from '@angular/common';
 import { ChipComponent } from '../../components/chip/chip';
 import { AppStateService } from '../../services/app-state.service';
 import { SyllabusService } from '../../services/syllabus.service';
+import { UnsyncedNoticeComponent } from '../../components/unsynced-notice/unsynced-notice';
 
 @Component({
   selector: 'app-chapter-tracker-page',
-  imports: [CommonModule, RouterModule, ChipComponent],
+  imports: [CommonModule, RouterModule, ChipComponent, UnsyncedNoticeComponent],
   templateUrl: './chapter-tracker-page.html',
   styleUrl: './chapter-tracker-page.scss'
 })

--- a/Orynth/src/app/pages/dashboard/dashboard-page.html
+++ b/Orynth/src/app/pages/dashboard/dashboard-page.html
@@ -1,4 +1,5 @@
 <div class="min-h-screen bg-gradient-to-br from-blue-50 to-green-50">
+  <app-unsynced-notice></app-unsynced-notice>
   <div class="bg-white/90 backdrop-blur-sm sticky top-0 z-10">
     <div class="flex items-center justify-between p-4">
       <a routerLink="/subject-list" class="p-2 hover:bg-gray-100 rounded-full tap-highlight">

--- a/Orynth/src/app/pages/dashboard/dashboard-page.ts
+++ b/Orynth/src/app/pages/dashboard/dashboard-page.ts
@@ -3,12 +3,13 @@ import { RouterModule } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { SubjectProgressRingComponent } from '../../components/subject-progress-ring/subject-progress-ring';
 import { ButtonComponent } from '../../components/button/button';
+import { UnsyncedNoticeComponent } from '../../components/unsynced-notice/unsynced-notice';
 import { AppStateService } from '../../services/app-state.service';
 import { SyllabusService } from '../../services/syllabus.service';
 
 @Component({
   selector: 'app-dashboard-page',
-  imports: [CommonModule, RouterModule, SubjectProgressRingComponent, ButtonComponent],
+  imports: [CommonModule, RouterModule, SubjectProgressRingComponent, ButtonComponent, UnsyncedNoticeComponent],
   templateUrl: './dashboard-page.html',
   styleUrl: './dashboard-page.scss'
 })

--- a/Orynth/src/app/pages/profile-page/profile-page.html
+++ b/Orynth/src/app/pages/profile-page/profile-page.html
@@ -1,0 +1,23 @@
+<div class="min-h-screen bg-gradient-to-br from-blue-50 to-green-50 p-6">
+  <h1 class="text-xl font-semibold mb-4">Profile</h1>
+  <p class="mb-4 text-sm text-gray-700">UID: {{ uid }}</p>
+
+  <div class="mb-4">
+    <label class="block mb-1 text-sm font-medium">Board</label>
+    <select [(ngModel)]="selectedBoard" (change)="updateClasses()" class="w-full p-2 rounded border">
+      <option *ngFor="let b of boards" [value]="b.id">{{ b.name }}</option>
+    </select>
+  </div>
+  <div class="mb-4">
+    <label class="block mb-1 text-sm font-medium">Standard</label>
+    <select [(ngModel)]="selectedClass" class="w-full p-2 rounded border">
+      <option *ngFor="let c of classes" [value]="c">Class {{ c }}</option>
+    </select>
+  </div>
+
+  <button (click)="save()" class="w-full h-12 bg-primary hover:bg-primary/90 text-white rounded-xl card-shadow mb-4">Save</button>
+
+  <div class="text-center" hidden>
+    <button class="w-full h-12 bg-gray-300 text-gray-500 rounded-xl" disabled>Upgrade Account</button>
+  </div>
+</div>

--- a/Orynth/src/app/pages/profile-page/profile-page.scss
+++ b/Orynth/src/app/pages/profile-page/profile-page.scss
@@ -1,0 +1,1 @@
+/* Add basic spacing */

--- a/Orynth/src/app/pages/profile-page/profile-page.ts
+++ b/Orynth/src/app/pages/profile-page/profile-page.ts
@@ -1,0 +1,59 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Firestore, doc, getDoc, setDoc } from '@angular/fire/firestore';
+import { AuthService } from '../../services/auth.service';
+import { AppStateService } from '../../services/app-state.service';
+import { SyllabusService } from '../../services/syllabus.service';
+
+@Component({
+  selector: 'app-profile-page',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './profile-page.html',
+  styleUrl: './profile-page.scss'
+})
+export class ProfilePageComponent implements OnInit {
+  uid = '';
+  boards: { id: string; name: string }[] = [];
+  classes: string[] = [];
+  selectedBoard = '';
+  selectedClass = '';
+  private syllabus: any = {};
+
+  constructor(
+    private firestore: Firestore,
+    private auth: AuthService,
+    private appState: AppStateService,
+    private syllabusService: SyllabusService
+  ) {}
+
+  ngOnInit(): void {
+    this.uid = this.auth.getCurrentUserId();
+    this.syllabusService.getSyllabusTree().subscribe(async data => {
+      this.syllabus = data || {};
+      this.boards = Object.keys(this.syllabus).map(id => ({ id, name: id }));
+      await this.loadProfile();
+    });
+  }
+
+  private async loadProfile() {
+    const profileRef = doc(this.firestore, `Users/${this.uid}/profile`);
+    const snap = await getDoc(profileRef);
+    const profile = snap.exists() ? snap.data() as any : {};
+    this.selectedBoard = profile.board || this.appState.getBoard();
+    this.updateClasses();
+    this.selectedClass = profile.standard || this.appState.getStandard();
+  }
+
+  updateClasses() {
+    this.classes = Object.keys(this.syllabus[this.selectedBoard] || {});
+  }
+
+  async save() {
+    this.appState.setBoard(this.selectedBoard);
+    this.appState.setStandard(this.selectedClass);
+    const profileRef = doc(this.firestore, `Users/${this.uid}/profile`);
+    await setDoc(profileRef, { board: this.selectedBoard, standard: this.selectedClass }, { merge: true });
+  }
+}

--- a/Orynth/src/app/pages/subject-list/subject-list-page.html
+++ b/Orynth/src/app/pages/subject-list/subject-list-page.html
@@ -1,4 +1,5 @@
 <div class="min-h-screen bg-gradient-to-br from-blue-50 to-green-50">
+  <app-unsynced-notice></app-unsynced-notice>
   <div class="bg-white/80 backdrop-blur-sm sticky top-0 z-10">
     <div class="flex items-center justify-between p-4">
       <a routerLink="/board-class-selection" class="p-2 hover:bg-white/20 rounded-full tap-highlight">

--- a/Orynth/src/app/pages/subject-list/subject-list-page.ts
+++ b/Orynth/src/app/pages/subject-list/subject-list-page.ts
@@ -3,10 +3,11 @@ import { RouterModule, Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { SyllabusService } from '../../services/syllabus.service';
 import { AppStateService } from '../../services/app-state.service';
+import { UnsyncedNoticeComponent } from '../../components/unsynced-notice/unsynced-notice';
 
 @Component({
   selector: 'app-subject-list-page',
-  imports: [CommonModule, RouterModule],
+  imports: [CommonModule, RouterModule, UnsyncedNoticeComponent],
   templateUrl: './subject-list-page.html',
   styleUrl: './subject-list-page.scss'
 })


### PR DESCRIPTION
## Summary
- create `ProfilePageComponent` for user profile settings
- add persistent `UnsyncedNoticeComponent`
- integrate unsynced banner across learning pages
- route `/profile` added

## Testing
- `npm ci`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6866333fad94832eb369bc6336d98184