### PR TITLE
Fix profile route and relocate unsynced notice

### DIFF
--- a/Orynth/src/app/app.routes.ts
+++ b/Orynth/src/app/app.routes.ts
@@ -1,5 +1,4 @@
 import { Routes } from '@angular/router';
-import { ProfilePageComponent } from './pages/profile-page/profile-page';
 
 export const routes: Routes = [
   { path: '', redirectTo: 'onboarding', pathMatch: 'full' },
@@ -25,7 +24,7 @@ export const routes: Routes = [
   },
   {
     path: 'profile',
-    component: ProfilePageComponent,
+    loadComponent: () => import('./pages/profile-page/profile-page').then(m => m.ProfilePageComponent),
     title: 'Profile'
   },
 ];

--- a/Orynth/src/app/pages/board-class-selection/board-class-selection-page.html
+++ b/Orynth/src/app/pages/board-class-selection/board-class-selection-page.html
@@ -1,5 +1,4 @@
 <div class="min-h-screen bg-gradient-to-br from-blue-50 to-green-50 flex flex-col">
-  <app-unsynced-notice></app-unsynced-notice>
   <div class="flex items-center justify-between p-4">
     <button (click)="step === 1 ? goHome() : step = 1" class="p-2 hover:bg-white/20 rounded-full tap-highlight">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-6 h-6 text-gray-700">

--- a/Orynth/src/app/pages/board-class-selection/board-class-selection-page.ts
+++ b/Orynth/src/app/pages/board-class-selection/board-class-selection-page.ts
@@ -3,11 +3,10 @@ import { CommonModule } from '@angular/common';
 import { RouterModule, Router } from '@angular/router';
 import { AppStateService } from '../../services/app-state.service';
 import { SyllabusService } from '../../services/syllabus.service';
-import { UnsyncedNoticeComponent } from '../../components/unsynced-notice/unsynced-notice';
 
 @Component({
   selector: 'app-board-class-selection-page',
-  imports: [CommonModule, RouterModule, UnsyncedNoticeComponent],
+  imports: [CommonModule, RouterModule],
   templateUrl: './board-class-selection-page.html'
 })
 export class BoardClassSelectionPageComponent implements OnInit {

--- a/Orynth/src/app/pages/chapter-tracker/chapter-tracker-page.html
+++ b/Orynth/src/app/pages/chapter-tracker/chapter-tracker-page.html
@@ -1,5 +1,4 @@
 <div class="min-h-screen bg-gradient-to-br from-blue-50 to-green-50">
-  <app-unsynced-notice></app-unsynced-notice>
   <div class="bg-white/90 backdrop-blur-sm sticky top-0 z-10 border-b border-gray-200">
     <div class="flex items-center justify-between p-4">
       <a routerLink="/subject-list" class="p-2 hover:bg-gray-100 rounded-full tap-highlight">

--- a/Orynth/src/app/pages/chapter-tracker/chapter-tracker-page.ts
+++ b/Orynth/src/app/pages/chapter-tracker/chapter-tracker-page.ts
@@ -4,7 +4,6 @@ import { CommonModule } from '@angular/common';
 import { ChipComponent } from '../../components/chip/chip';
 import { AppStateService } from '../../services/app-state.service';
 import { SyllabusService } from '../../services/syllabus.service';
-import { UnsyncedNoticeComponent } from '../../components/unsynced-notice/unsynced-notice';
 import { BottomNavComponent } from '../../components/bottom-nav/bottom-nav';
 
 @Component({
@@ -13,7 +12,6 @@ import { BottomNavComponent } from '../../components/bottom-nav/bottom-nav';
     CommonModule,
     RouterModule,
     ChipComponent,
-    UnsyncedNoticeComponent,
     BottomNavComponent
   ],
   templateUrl: './chapter-tracker-page.html',

--- a/Orynth/src/app/pages/dashboard/dashboard-page.html
+++ b/Orynth/src/app/pages/dashboard/dashboard-page.html
@@ -1,5 +1,4 @@
 <div class="min-h-screen bg-gradient-to-br from-blue-50 to-green-50">
-  <app-unsynced-notice></app-unsynced-notice>
   <div class="bg-white/90 backdrop-blur-sm sticky top-0 z-10">
     <div class="flex items-center justify-between p-4">
       <a routerLink="/subject-list" class="p-2 hover:bg-gray-100 rounded-full tap-highlight">

--- a/Orynth/src/app/pages/dashboard/dashboard-page.ts
+++ b/Orynth/src/app/pages/dashboard/dashboard-page.ts
@@ -3,7 +3,6 @@ import { RouterModule } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { SubjectProgressRingComponent } from '../../components/subject-progress-ring/subject-progress-ring';
 import { ButtonComponent } from '../../components/button/button';
-import { UnsyncedNoticeComponent } from '../../components/unsynced-notice/unsynced-notice';
 import { BottomNavComponent } from '../../components/bottom-nav/bottom-nav';
 import { AppStateService } from '../../services/app-state.service';
 import { SyllabusService } from '../../services/syllabus.service';
@@ -15,7 +14,6 @@ import { SyllabusService } from '../../services/syllabus.service';
     RouterModule,
     SubjectProgressRingComponent,
     ButtonComponent,
-    UnsyncedNoticeComponent,
     BottomNavComponent
   ],
   templateUrl: './dashboard-page.html',

--- a/Orynth/src/app/pages/subject-list/subject-list-page.html
+++ b/Orynth/src/app/pages/subject-list/subject-list-page.html
@@ -1,5 +1,4 @@
 <div class="min-h-screen bg-gradient-to-br from-blue-50 to-green-50">
-  <app-unsynced-notice></app-unsynced-notice>
   <div class="bg-white/80 backdrop-blur-sm sticky top-0 z-10">
     <div class="flex items-center justify-between p-4">
       <a routerLink="/board-class-selection" class="p-2 hover:bg-white/20 rounded-full tap-highlight">
@@ -56,6 +55,7 @@
         </div>
       </div>
     </div>
+    <app-unsynced-notice></app-unsynced-notice>
   </div>
 </div>
 <app-bottom-nav></app-bottom-nav>


### PR DESCRIPTION
## Summary
- fix routing for profile page
- remove Unsynced notice from all pages except home
- show Unsynced notice under Quick Stats on home page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686681bf57f0832e846b8eb48cc8f469