### PR TITLE
Fix bottom navigation

### DIFF
--- a/Orynth/src/app/components/bottom-nav/bottom-nav.html
+++ b/Orynth/src/app/components/bottom-nav/bottom-nav.html
@@ -1,6 +1,6 @@
 <div class="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 px-6 py-3 z-50">
   <div class="flex justify-around items-center max-w-sm mx-auto">
-    <a routerLink="/" routerLinkActive="active-link" [routerLinkActiveOptions]="{ exact: true }" class="flex flex-col items-center space-y-1 tap-highlight text-gray-600">
+    <a routerLink="/subject-list" routerLinkActive="active-link" [routerLinkActiveOptions]="{ exact: true }" class="flex flex-col items-center space-y-1 tap-highlight text-gray-600">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" class="w-6 h-6">
         <path d="M3 9.5L12 3l9 6.5V21a1 1 0 0 1-1 1h-5v-6H9v6H4a1 1 0 0 1-1-1V9.5z" />
       </svg>

--- a/Orynth/src/app/pages/onboarding/onboarding-page.ts
+++ b/Orynth/src/app/pages/onboarding/onboarding-page.ts
@@ -1,15 +1,37 @@
-import { Component } from '@angular/core';
-import { RouterModule } from '@angular/router';
+import { Component, OnInit } from '@angular/core';
+import { Router, RouterModule } from '@angular/router';
 import { AuthService } from '../../services/auth.service';
+import { Firestore, doc, getDoc } from '@angular/fire/firestore';
+import { AppStateService } from '../../services/app-state.service';
 
 @Component({
   selector: 'app-onboarding-page',
   imports: [RouterModule],
   templateUrl: './onboarding-page.html'
 })
-export class OnboardingPageComponent {
+export class OnboardingPageComponent implements OnInit {
 
-  constructor(private auth: AuthService) {}
+  constructor(
+    private auth: AuthService,
+    private firestore: Firestore,
+    private appState: AppStateService,
+    private router: Router
+  ) {}
+
+  async ngOnInit() {
+    const user = await this.auth.signInAnonymouslyIfNeeded();
+    const profileRef = doc(this.firestore, `Users/${user.uid}/profile`);
+    const snap = await getDoc(profileRef);
+    if (snap.exists()) {
+      const profile = snap.data() as any;
+      if (profile.board && profile.standard) {
+        this.appState.setBoard(profile.board);
+        this.appState.setStandard(profile.standard);
+        this.router.navigate(['/subject-list']);
+        return;
+      }
+    }
+  }
 
   async startTracking() {
     const user = await this.auth.signInAnonymouslyIfNeeded();

--- a/Orynth/src/app/pages/profile-page/profile-page.ts
+++ b/Orynth/src/app/pages/profile-page/profile-page.ts
@@ -32,7 +32,12 @@ export class ProfilePageComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.uid = this.auth.getCurrentUserId();
+    this.init();
+  }
+
+  private async init() {
+    const user = await this.auth.signInAnonymouslyIfNeeded();
+    this.uid = user.uid;
     this.syllabusService.getSyllabusTree().subscribe(async data => {
       this.syllabus = data || {};
       this.boards = Object.keys(this.syllabus).map(id => ({ id, name: id }));


### PR DESCRIPTION
## Summary
- restore onboarding as default route
- auto-redirect to subject list when profile is complete

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6867d6aae178832e863edb5d263d1d29