### PR TITLE
Handle anonymous login failures

### DIFF
--- a/Orynth/src/app/pages/onboarding/onboarding-page.ts
+++ b/Orynth/src/app/pages/onboarding/onboarding-page.ts
@@ -20,6 +20,9 @@ export class OnboardingPageComponent implements OnInit {
 
   async ngOnInit() {
     const user = await this.auth.signInAnonymouslyIfNeeded();
+    if (!user) {
+      return;
+    }
     const profileRef = doc(this.firestore, `Users/${user.uid}/profile`);
     const snap = await getDoc(profileRef);
     if (snap.exists()) {
@@ -35,6 +38,8 @@ export class OnboardingPageComponent implements OnInit {
 
   async startTracking() {
     const user = await this.auth.signInAnonymouslyIfNeeded();
-    console.log('Auth UID:', user.uid);
+    if (user) {
+      console.log('Auth UID:', user.uid);
+    }
   }
 }

--- a/Orynth/src/app/pages/profile-page/profile-page.ts
+++ b/Orynth/src/app/pages/profile-page/profile-page.ts
@@ -37,6 +37,9 @@ export class ProfilePageComponent implements OnInit {
 
   private async init() {
     const user = await this.auth.signInAnonymouslyIfNeeded();
+    if (!user) {
+      return;
+    }
     this.uid = user.uid;
     this.syllabusService.getSyllabusTree().subscribe(async data => {
       this.syllabus = data || {};

--- a/Orynth/src/app/services/auth.service.ts
+++ b/Orynth/src/app/services/auth.service.ts
@@ -12,12 +12,17 @@ export class AuthService {
     this.authState$ = authState(this.auth);
   }
 
-  async signInAnonymouslyIfNeeded(): Promise<User> {
+  async signInAnonymouslyIfNeeded(): Promise<User | null> {
     if (this.auth.currentUser) {
       return this.auth.currentUser;
     }
-    const cred = await signInAnonymously(this.auth);
-    return cred.user;
+    try {
+      const cred = await signInAnonymously(this.auth);
+      return cred.user;
+    } catch (error) {
+      console.error('Anonymous sign-in failed', error);
+      return this.auth.currentUser ?? null;
+    }
   }
 
   getCurrentUserId(): string {


### PR DESCRIPTION
## Summary
- catch anonymous login failures in `AuthService`
- guard onboarding/profile pages if anonymous login fails
- log UID only if login succeeds

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6868d1f17b04832eb330e4ffaf19cda6