### PR TITLE
Fix onboarding redirect flow

### DIFF
--- a/Orynth/src/app/pages/onboarding/onboarding-page.ts
+++ b/Orynth/src/app/pages/onboarding/onboarding-page.ts
@@ -21,19 +21,24 @@ export class OnboardingPageComponent implements OnInit {
   async ngOnInit() {
     const user = await this.auth.signInAnonymouslyIfNeeded();
     if (!user) {
+      await this.router.navigate(['/board-class-selection']);
       return;
     }
+
     const profileRef = doc(this.firestore, `Users/${user.uid}/profile`);
     const snap = await getDoc(profileRef);
+
     if (snap.exists()) {
       const profile = snap.data() as any;
       if (profile.board && profile.standard) {
         this.appState.setBoard(profile.board);
         this.appState.setStandard(profile.standard);
-        this.router.navigate(['/subject-list']);
+        await this.router.navigate(['/subject-list']);
         return;
       }
     }
+
+    await this.router.navigate(['/board-class-selection']);
   }
 
   async startTracking() {


### PR DESCRIPTION
## Summary
- redirect from onboarding to board class selection when profile is missing

## Testing
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868d9089d7c832e92ca4833223d8ce2