### PR TITLE
Fix Firestore initialization and update components to standalone

### DIFF
--- a/Orynth/src/app/app.config.ts
+++ b/Orynth/src/app/app.config.ts
@@ -11,6 +11,9 @@ import { environment } from '../environments/environment';
 
 import { routes } from './app.routes';
 
+const firestore = getFirestore();
+enableIndexedDbPersistence(firestore).catch(() => {});
+
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
@@ -24,10 +27,6 @@ export const appConfig: ApplicationConfig = {
       setPersistence(auth, browserLocalPersistence);
       return auth;
     }),
-    provideFirestore(() => {
-      const firestore = getFirestore();
-      enableIndexedDbPersistence(firestore).catch(() => {});
-      return firestore;
-    })
+    provideFirestore(() => firestore)
   ]
 };

--- a/Orynth/src/app/app.ts
+++ b/Orynth/src/app/app.ts
@@ -3,6 +3,7 @@ import { RouterOutlet } from '@angular/router';
 
 @Component({
   selector: 'app-root',
+  standalone: true,
   imports: [RouterOutlet],
   templateUrl: './app.html',
   styleUrl: './app.scss'

--- a/Orynth/src/app/components/button/button.ts
+++ b/Orynth/src/app/components/button/button.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-button',
+  standalone: true,
   imports: [CommonModule],
   templateUrl: './button.html',
   styleUrl: './button.scss'

--- a/Orynth/src/app/components/card/card.ts
+++ b/Orynth/src/app/components/card/card.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-card',
+  standalone: true,
   imports: [CommonModule],
   templateUrl: './card.html',
   styleUrl: './card.scss'

--- a/Orynth/src/app/components/chip/chip.ts
+++ b/Orynth/src/app/components/chip/chip.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-chip',
+  standalone: true,
   imports: [CommonModule],
   templateUrl: './chip.html',
   styleUrl: './chip.scss'

--- a/Orynth/src/app/components/header/header.ts
+++ b/Orynth/src/app/components/header/header.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-header',
+  standalone: true,
   imports: [CommonModule],
   templateUrl: './header.html',
   styleUrl: './header.scss'

--- a/Orynth/src/app/components/login-upgrade-modal/login-upgrade-modal.ts
+++ b/Orynth/src/app/components/login-upgrade-modal/login-upgrade-modal.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-login-upgrade-modal',
+  standalone: true,
   imports: [CommonModule],
   templateUrl: './login-upgrade-modal.html'
 })

--- a/Orynth/src/app/components/progress-bar/progress-bar.ts
+++ b/Orynth/src/app/components/progress-bar/progress-bar.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-progress-bar',
+  standalone: true,
   imports: [CommonModule],
   templateUrl: './progress-bar.html',
   styleUrl: './progress-bar.scss'

--- a/Orynth/src/app/components/subject-progress-ring/subject-progress-ring.ts
+++ b/Orynth/src/app/components/subject-progress-ring/subject-progress-ring.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-subject-progress-ring',
+  standalone: true,
   imports: [CommonModule],
   templateUrl: './subject-progress-ring.html',
   styleUrl: './subject-progress-ring.scss'

--- a/Orynth/src/app/pages/board-class-selection/board-class-selection-page.ts
+++ b/Orynth/src/app/pages/board-class-selection/board-class-selection-page.ts
@@ -6,6 +6,7 @@ import { SyllabusService } from '../../services/syllabus.service';
 
 @Component({
   selector: 'app-board-class-selection-page',
+  standalone: true,
   imports: [CommonModule, RouterModule],
   templateUrl: './board-class-selection-page.html'
 })

--- a/Orynth/src/app/pages/chapter-tracker/chapter-tracker-page.ts
+++ b/Orynth/src/app/pages/chapter-tracker/chapter-tracker-page.ts
@@ -8,6 +8,7 @@ import { BottomNavComponent } from '../../components/bottom-nav/bottom-nav';
 
 @Component({
   selector: 'app-chapter-tracker-page',
+  standalone: true,
   imports: [
     CommonModule,
     RouterModule,

--- a/Orynth/src/app/pages/dashboard/dashboard-page.ts
+++ b/Orynth/src/app/pages/dashboard/dashboard-page.ts
@@ -9,6 +9,7 @@ import { SyllabusService } from '../../services/syllabus.service';
 
 @Component({
   selector: 'app-dashboard-page',
+  standalone: true,
   imports: [
     CommonModule,
     RouterModule,

--- a/Orynth/src/app/pages/onboarding/onboarding-page.ts
+++ b/Orynth/src/app/pages/onboarding/onboarding-page.ts
@@ -6,6 +6,7 @@ import { AppStateService } from '../../services/app-state.service';
 
 @Component({
   selector: 'app-onboarding-page',
+  standalone: true,
   imports: [RouterModule],
   templateUrl: './onboarding-page.html'
 })

--- a/Orynth/src/app/pages/subject-list/subject-list-page.ts
+++ b/Orynth/src/app/pages/subject-list/subject-list-page.ts
@@ -8,6 +8,7 @@ import { BottomNavComponent } from '../../components/bottom-nav/bottom-nav';
 
 @Component({
   selector: 'app-subject-list-page',
+  standalone: true,
   imports: [CommonModule, RouterModule, UnsyncedNoticeComponent, BottomNavComponent],
   templateUrl: './subject-list-page.html',
   styleUrl: './subject-list-page.scss'


### PR DESCRIPTION
## Summary
- set up Firestore persistence before providing Firestore
- mark root app and all components/pages as `standalone`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6868e3e47100832ea28a5aea2b926dee