### PR TITLE
Fix Firebase initialization timing

### DIFF
--- a/Orynth/src/app/app.config.ts
+++ b/Orynth/src/app/app.config.ts
@@ -11,8 +11,7 @@ import { environment } from '../environments/environment';
 
 import { routes } from './app.routes';
 
-const firestore = getFirestore();
-enableIndexedDbPersistence(firestore).catch(() => {});
+
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -27,6 +26,10 @@ export const appConfig: ApplicationConfig = {
       setPersistence(auth, browserLocalPersistence);
       return auth;
     }),
-    provideFirestore(() => firestore)
+    provideFirestore(() => {
+      const firestore = getFirestore();
+      enableIndexedDbPersistence(firestore).catch(() => {});
+      return firestore;
+    })
   ]
 };

--- a/Orynth/src/app/app.routes.ts
+++ b/Orynth/src/app/app.routes.ts
@@ -27,4 +27,8 @@ export const routes: Routes = [
     loadComponent: () => import('./pages/profile-page/profile-page').then(m => m.ProfilePageComponent),
     title: 'Profile'
   },
+  {
+    path: 'firebase-test',
+    loadComponent: () => import('./components/firebase-test/firebase-test.component').then(m => m.FirebaseTestComponent)
+  },
 ];

--- a/Orynth/src/app/components/firebase-test/firebase-test.component.ts
+++ b/Orynth/src/app/components/firebase-test/firebase-test.component.ts
@@ -1,0 +1,23 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Firestore, doc, getDoc } from '@angular/fire/firestore';
+
+@Component({
+  selector: 'app-firebase-test',
+  standalone: true,
+  imports: [CommonModule],
+  template: `<p>firebase test works</p>`
+})
+export class FirebaseTestComponent implements OnInit {
+  constructor(private firestore: Firestore) {}
+
+  async ngOnInit() {
+    try {
+      const ref = doc(this.firestore, 'test/doc');
+      const snap = await getDoc(ref);
+      console.log('Firebase test success:', snap.exists());
+    } catch (err) {
+      console.error('Firebase test error:', err);
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "Orynth",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
## Summary
- initialize Firestore after the Firebase app is created
- provide persistence inside the Firestore provider
- add a simple FirebaseTestComponent and route for debugging

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68690148d140832ebd495a4b064ea384