### PR TITLE
Fix Firestore persistence crash

### DIFF
--- a/Orynth/src/app/app.config.ts
+++ b/Orynth/src/app/app.config.ts
@@ -4,9 +4,10 @@ import { provideServiceWorker } from '@angular/service-worker';
 import { provideRouter } from '@angular/router';
 import { provideFirebaseApp, initializeApp } from '@angular/fire/app';
 import { provideAuth, getAuth } from '@angular/fire/auth';
-import { provideFirestore, getFirestore } from '@angular/fire/firestore';
+import { provideFirestore } from '@angular/fire/firestore';
 import { setPersistence, browserLocalPersistence } from 'firebase/auth';
-import { enableIndexedDbPersistence } from 'firebase/firestore';
+import { initializeFirestore, persistentLocalCache, persistentMultipleTabManager } from 'firebase/firestore';
+import { getApp } from 'firebase/app';
 import { environment } from '../environments/environment';
 
 import { routes } from './app.routes';
@@ -26,10 +27,10 @@ export const appConfig: ApplicationConfig = {
       setPersistence(auth, browserLocalPersistence);
       return auth;
     }),
-    provideFirestore(() => {
-      const firestore = getFirestore();
-      //enableIndexedDbPersistence(firestore).catch(() => {});
-      return firestore;
-    })
+    provideFirestore(() =>
+      initializeFirestore(getApp(), {
+        localCache: persistentLocalCache({ tabManager: persistentMultipleTabManager() })
+      })
+    )
   ]
 };


### PR DESCRIPTION
## Summary
- use Firebase modular API to initialize Firestore with persistent local cache
- keep persistence enabled safely so app doesn't crash in incognito or multi-tab

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68690c0b96d0832eb1b70ac02689a6f9