### PR TITLE
Fix bottom nav overlap

### DIFF
--- a/Orynth/src/app/pages/chapter-tracker/chapter-tracker-page.html
+++ b/Orynth/src/app/pages/chapter-tracker/chapter-tracker-page.html
@@ -1,4 +1,4 @@
-<div class="min-h-screen bg-gradient-to-br from-blue-50 to-green-50">
+<div class="min-h-screen bg-gradient-to-br from-blue-50 to-green-50 page-wrapper">
   <div class="bg-white/90 backdrop-blur-sm sticky top-0 z-10 border-b border-gray-200">
     <div class="flex items-center justify-between p-4">
       <a routerLink="/subject-list" class="p-2 hover:bg-gray-100 rounded-full tap-highlight">

--- a/Orynth/src/app/pages/dashboard/dashboard-page.html
+++ b/Orynth/src/app/pages/dashboard/dashboard-page.html
@@ -1,4 +1,4 @@
-<div class="min-h-screen bg-gradient-to-br from-blue-50 to-green-50">
+<div class="min-h-screen bg-gradient-to-br from-blue-50 to-green-50 page-wrapper">
   <div class="bg-white/90 backdrop-blur-sm sticky top-0 z-10">
     <div class="flex items-center justify-between p-4">
       <a routerLink="/subject-list" class="p-2 hover:bg-gray-100 rounded-full tap-highlight">

--- a/Orynth/src/app/pages/profile-page/profile-page.html
+++ b/Orynth/src/app/pages/profile-page/profile-page.html
@@ -1,4 +1,4 @@
-<div class="min-h-screen bg-gradient-to-br from-blue-50 to-green-50 pb-20">
+<div class="min-h-screen bg-gradient-to-br from-blue-50 to-green-50 page-wrapper">
   <div class="bg-white/80 backdrop-blur-sm sticky top-0 z-10">
     <div class="text-center py-4">
       <h1 class="text-lg font-semibold text-gray-900">Your Profile</h1>

--- a/Orynth/src/app/pages/subject-list/subject-list-page.html
+++ b/Orynth/src/app/pages/subject-list/subject-list-page.html
@@ -1,4 +1,4 @@
-<div class="min-h-screen bg-gradient-to-br from-blue-50 to-green-50">
+<div class="min-h-screen bg-gradient-to-br from-blue-50 to-green-50 page-wrapper">
   <div class="bg-white/80 backdrop-blur-sm sticky top-0 z-10">
     <div class="flex items-center justify-between p-4">
       <a routerLink="/board-class-selection" class="p-2 hover:bg-white/20 rounded-full tap-highlight">

--- a/Orynth/src/styles.scss
+++ b/Orynth/src/styles.scss
@@ -54,4 +54,12 @@
   .card-shadow-hover {
     box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.08), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
   }
+  .page-wrapper {
+    padding-bottom: calc(80px + env(safe-area-inset-bottom));
+  }
+  @media (min-width: 768px) {
+    .page-wrapper {
+      padding-bottom: calc(96px + env(safe-area-inset-bottom));
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- add `.page-wrapper` utility with bottom padding
- apply `page-wrapper` to main pages so scrolling content stays above bottom nav

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686926128828832eb94b6dfbcb5ad3de