### PR TITLE
Implement Firestore sync

### DIFF
--- a/Orynth/src/app/services/progress/progress.service.ts
+++ b/Orynth/src/app/services/progress/progress.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
-import { Firestore, doc, setDoc } from '@angular/fire/firestore';
+import { Firestore, doc, setDoc, docData } from '@angular/fire/firestore';
+import { Observable } from 'rxjs';
 import { AuthService } from '../auth.service';
 
 @Injectable({
@@ -13,5 +14,11 @@ export class ProgressService {
     const uid = this.auth.getCurrentUserId();
     const ref = doc(this.firestore, `Users/${uid}/Progress/${subjectId}`);
     await setDoc(ref, data, { merge: true });
+  }
+
+  getProgress(subjectId: string): Observable<any | undefined> {
+    const uid = this.auth.getCurrentUserId();
+    const ref = doc(this.firestore, `Users/${uid}/Progress/${subjectId}`);
+    return docData(ref);
   }
 }


### PR DESCRIPTION
## Summary
- store Google login details in `Users/<uid>/info`
- add Firestore progress service with snapshot support
- sync chapter tracker with Firestore progress
- load subject progress from Firestore

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6869f3f48c94832ea938c622de1a32e1