### PR TITLE
Fix Google login redirect

### DIFF
--- a/Orynth/src/app/pages/login/login-page.ts
+++ b/Orynth/src/app/pages/login/login-page.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { RouterModule } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
 import { AuthService } from '../../services/auth.service';
 
 @Component({
@@ -11,9 +11,10 @@ import { AuthService } from '../../services/auth.service';
   styleUrl: './login-page.scss'
 })
 export class LoginPageComponent {
-  constructor(private auth: AuthService) {}
+  constructor(private auth: AuthService, private router: Router) {}
 
   async loginWithGoogle() {
     await this.auth.upgradeWithGoogle();
+    await this.router.navigate(['/subject-list']);
   }
 }


### PR DESCRIPTION
## Summary
- add Router dependency to login page
- redirect to the home/subject list page after Google login

## Testing
- `npm run build --prefix Orynth`

------
https://chatgpt.com/codex/tasks/task_e_6869fe7da474832e9c2d313a6fce9a37