### PR TITLE
Fix Firestore paths and store user data in root doc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,20 @@ npm run build
 If the build fails, fix the issue before committing.
 Report the result of the build in the Testing section of your pull request message.
 
+Firestore reads and writes must target a document path with an **even number of
+segments**. The main user document lives at `Users/{uid}`. Store all related
+data (basic info, profile details and syllabus progress) inside that document as
+nested objects:
+
+```
+Users/{uid}
+  info
+  profile
+  progress
+```
+Avoid paths like `Users/{uid}/profile` which omit the final segment and produce
+`Invalid document reference` errors.
+
 ## Screen Flow
 
 1. Onboarding – onboarding

--- a/Orynth/src/app/pages/onboarding/onboarding-page.ts
+++ b/Orynth/src/app/pages/onboarding/onboarding-page.ts
@@ -26,11 +26,12 @@ export class OnboardingPageComponent implements OnInit {
       return;
     }
 
-    const profileRef = doc(this.firestore, `Users/${user.uid}/profile`);
+    const profileRef = doc(this.firestore, `Users/${user.uid}`);
     const snap = await getDoc(profileRef);
 
     if (snap.exists()) {
-      const profile = snap.data() as any;
+      const data = snap.data() as any;
+      const profile = data.profile || {};
       if (profile.board && profile.standard) {
         this.appState.setBoard(profile.board);
         this.appState.setStandard(profile.standard);

--- a/Orynth/src/app/pages/profile-page/profile-page.ts
+++ b/Orynth/src/app/pages/profile-page/profile-page.ts
@@ -49,9 +49,10 @@ export class ProfilePageComponent implements OnInit {
   }
 
   private async loadProfile() {
-    const profileRef = doc(this.firestore, `Users/${this.uid}/profile`);
+    const profileRef = doc(this.firestore, `Users/${this.uid}`);
     const snap = await getDoc(profileRef);
-    const profile = snap.exists() ? snap.data() as any : {};
+    const data = snap.exists() ? snap.data() as any : {};
+    const profile = data.profile || {};
     this.selectedBoard = profile.board || this.appState.getBoard();
     this.updateClasses();
     this.selectedClass = profile.standard || this.appState.getStandard();
@@ -66,12 +67,14 @@ export class ProfilePageComponent implements OnInit {
   async save() {
     this.appState.setBoard(this.selectedBoard);
     this.appState.setStandard(this.selectedClass);
-    const profileRef = doc(this.firestore, `Users/${this.uid}/profile`);
+    const profileRef = doc(this.firestore, `Users/${this.uid}`);
     await setDoc(profileRef, {
-      board: this.selectedBoard,
-      standard: this.selectedClass,
-      school: this.school,
-      birthDate: this.birthDate
+      profile: {
+        board: this.selectedBoard,
+        standard: this.selectedClass,
+        school: this.school,
+        birthDate: this.birthDate
+      }
     }, { merge: true });
   }
 }

--- a/Orynth/src/app/services/auth.service.ts
+++ b/Orynth/src/app/services/auth.service.ts
@@ -47,11 +47,13 @@ export class AuthService {
   }
 
   private async saveUserInfo(user: User) {
-    const ref = doc(this.firestore, `Users/${user.uid}/info`);
+    const ref = doc(this.firestore, `Users/${user.uid}`);
     await setDoc(ref, {
-      displayName: user.displayName ?? '',
-      email: user.email ?? '',
-      photoURL: user.photoURL ?? ''
+      info: {
+        displayName: user.displayName ?? '',
+        email: user.email ?? '',
+        photoURL: user.photoURL ?? ''
+      }
     }, { merge: true });
   }
 }

--- a/Orynth/src/app/services/progress/progress.service.ts
+++ b/Orynth/src/app/services/progress/progress.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Firestore, doc, setDoc, docData } from '@angular/fire/firestore';
-import { Observable } from 'rxjs';
+import { Observable, map } from 'rxjs';
 import { AuthService } from '../auth.service';
 
 @Injectable({
@@ -12,13 +12,15 @@ export class ProgressService {
 
   async setProgress(subjectId: string, data: any) {
     const uid = this.auth.getCurrentUserId();
-    const ref = doc(this.firestore, `Users/${uid}/Progress/${subjectId}`);
-    await setDoc(ref, data, { merge: true });
+    const ref = doc(this.firestore, `Users/${uid}`);
+    await setDoc(ref, { progress: { [subjectId]: data } }, { merge: true });
   }
 
   getProgress(subjectId: string): Observable<any | undefined> {
     const uid = this.auth.getCurrentUserId();
-    const ref = doc(this.firestore, `Users/${uid}/Progress/${subjectId}`);
-    return docData(ref);
+    const ref = doc(this.firestore, `Users/${uid}`);
+    return docData(ref).pipe(
+      map(data => (data as any)?.progress?.[subjectId])
+    );
   }
 }

--- a/README.md
+++ b/README.md
@@ -53,6 +53,22 @@ npm run dev
 - **Profile Page** – The React profile page reads and writes all details from
   `localStorage`, whereas the Angular page syncs them with Firestore.
 
+## Firestore Document Paths
+
+Always pass an **even number of path segments** to `doc()` so it points to a
+specific document. The top-level user document lives at `Users/{uid}` (two
+segments). Store all user information under that document:
+
+```text
+Users/{uid}
+  info: { displayName, email, photoURL }
+  profile: { board, standard, school, birthDate }
+  progress: { [subjectId]: ChapterProgress[] }
+```
+
+Avoid paths like `Users/{uid}/profile` which have an odd number of segments and
+result in an `Invalid document reference` error.
+
 ## Feature Audit: Phase 1
 
 - **Landing / Onboarding – 🟡 Partial**


### PR DESCRIPTION
## Summary
- keep all user-related data under `Users/{uid}`
- update services and pages to match new structure
- document the Firestore path rule and structure

## Testing
- `npm ci`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686a9c8fe058832e9d36b4c9e9bdff89