### PR TITLE
Fix anonymous sync writes

### DIFF
--- a/Orynth/src/app/pages/profile-page/profile-page.ts
+++ b/Orynth/src/app/pages/profile-page/profile-page.ts
@@ -67,14 +67,16 @@ export class ProfilePageComponent implements OnInit {
   async save() {
     this.appState.setBoard(this.selectedBoard);
     this.appState.setStandard(this.selectedClass);
-    const profileRef = doc(this.firestore, `Users/${this.uid}`);
-    await setDoc(profileRef, {
-      profile: {
-        board: this.selectedBoard,
-        standard: this.selectedClass,
-        school: this.school,
-        birthDate: this.birthDate
-      }
-    }, { merge: true });
+    if (this.auth.isLoggedIn()) {
+      const profileRef = doc(this.firestore, `Users/${this.uid}`);
+      await setDoc(profileRef, {
+        profile: {
+          board: this.selectedBoard,
+          standard: this.selectedClass,
+          school: this.school,
+          birthDate: this.birthDate
+        }
+      }, { merge: true });
+    }
   }
 }

--- a/Orynth/src/app/services/auth.service.ts
+++ b/Orynth/src/app/services/auth.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Auth, signInAnonymously, User, authState, linkWithPopup, GoogleAuthProvider, linkWithPhoneNumber } from '@angular/fire/auth';
+import { Auth, signInAnonymously, User, authState, linkWithPopup, GoogleAuthProvider, linkWithPhoneNumber, signInWithPopup } from '@angular/fire/auth';
 import { Observable } from 'rxjs';
 import { Firestore, doc, setDoc } from '@angular/fire/firestore';
 
@@ -31,14 +31,27 @@ export class AuthService {
   }
 
   isLoggedIn(): boolean {
-    return !!this.auth.currentUser;
+    return !!this.auth.currentUser && !this.auth.currentUser.isAnonymous;
+  }
+
+  isAnonymous(): boolean {
+    return !!this.auth.currentUser && this.auth.currentUser.isAnonymous;
   }
 
   async upgradeWithGoogle() {
     if (!this.auth.currentUser) throw new Error('No current user');
-    const cred = await linkWithPopup(this.auth.currentUser, new GoogleAuthProvider());
-    await this.saveUserInfo(cred.user);
-    return cred;
+    try {
+      const cred = await linkWithPopup(this.auth.currentUser, new GoogleAuthProvider());
+      await this.saveUserInfo(cred.user);
+      return cred;
+    } catch (err: any) {
+      if (err.code === 'auth/credential-already-in-use') {
+        const cred = await signInWithPopup(this.auth, new GoogleAuthProvider());
+        await this.saveUserInfo(cred.user);
+        return cred;
+      }
+      throw err;
+    }
   }
 
   async upgradeWithPhoneNumber(phoneNumber: string, appVerifier: any) {

--- a/Orynth/src/app/services/progress/progress.service.ts
+++ b/Orynth/src/app/services/progress/progress.service.ts
@@ -16,6 +16,9 @@ export class ProgressService {
   ) { }
 
   async setProgress(subjectId: string, data: any) {
+    if (!this.auth.isLoggedIn()) {
+      return;
+    }
     const uid = this.auth.getCurrentUserId();
     const board = this.appState.getBoard();
     const standard = this.appState.getStandard();


### PR DESCRIPTION
## Summary
- prevent anonymous users from writing to Firestore
- handle credential-already-in-use on Google upgrade
- only sync profile and progress once the user is fully logged in

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686b6c38b56c832e8104cb9fa29fb774