### PR TITLE
Improve login flow and add logout button

### DIFF
--- a/Orynth/src/app/pages/login/login-page.ts
+++ b/Orynth/src/app/pages/login/login-page.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router, RouterModule } from '@angular/router';
 import { AuthService } from '../../services/auth.service';
@@ -10,8 +10,16 @@ import { AuthService } from '../../services/auth.service';
   templateUrl: './login-page.html',
   styleUrl: './login-page.scss'
 })
-export class LoginPageComponent {
+export class LoginPageComponent implements OnInit {
   constructor(private auth: AuthService, private router: Router) {}
+
+  ngOnInit(): void {
+    this.auth.authState$.subscribe(user => {
+      if (user && !user.isAnonymous) {
+        this.router.navigate(['/subject-list']);
+      }
+    });
+  }
 
   async loginWithGoogle() {
     await this.auth.upgradeWithGoogle();

--- a/Orynth/src/app/pages/onboarding/onboarding-page.ts
+++ b/Orynth/src/app/pages/onboarding/onboarding-page.ts
@@ -20,26 +20,27 @@ export class OnboardingPageComponent implements OnInit {
   ) {}
 
   async ngOnInit() {
-    if (!this.auth.isLoggedIn()) {
-      return;
-    }
-
-    const uid = this.auth.getCurrentUserId();
-    const profileRef = doc(this.firestore, `Users/${uid}`);
-    const snap = await getDoc(profileRef);
-
-    if (snap.exists()) {
-      const data = snap.data() as any;
-      const profile = data.profile || {};
-      if (profile.board && profile.standard) {
-        this.appState.setBoard(profile.board);
-        this.appState.setStandard(profile.standard);
-        await this.router.navigate(['/subject-list']);
+    this.auth.authState$.subscribe(async user => {
+      if (!user || user.isAnonymous) {
         return;
       }
-    }
 
-    await this.router.navigate(['/board-class-selection']);
+      const profileRef = doc(this.firestore, `Users/${user.uid}`);
+      const snap = await getDoc(profileRef);
+
+      if (snap.exists()) {
+        const data = snap.data() as any;
+        const profile = data.profile || {};
+        if (profile.board && profile.standard) {
+          this.appState.setBoard(profile.board);
+          this.appState.setStandard(profile.standard);
+          await this.router.navigate(['/subject-list']);
+          return;
+        }
+      }
+
+      await this.router.navigate(['/board-class-selection']);
+    });
   }
 
   async startTracking() {

--- a/Orynth/src/app/pages/profile-page/profile-page.html
+++ b/Orynth/src/app/pages/profile-page/profile-page.html
@@ -4,6 +4,7 @@
       <div class="w-10"></div>
       <h1 class="text-lg font-semibold text-gray-900">Your Profile</h1>
       <a *ngIf="(auth.authState$ | async)?.isAnonymous" routerLink="/login" class="text-sm font-medium text-primary tap-highlight">Login</a>
+      <button *ngIf="!(auth.authState$ | async)?.isAnonymous" (click)="logout()" class="text-sm font-medium text-primary tap-highlight">Logout</button>
     </div>
   </div>
 

--- a/Orynth/src/app/pages/profile-page/profile-page.ts
+++ b/Orynth/src/app/pages/profile-page/profile-page.ts
@@ -6,6 +6,7 @@ import { Firestore, doc, getDoc, setDoc } from '@angular/fire/firestore';
 import { AuthService } from '../../services/auth.service';
 import { AppStateService } from '../../services/app-state.service';
 import { SyllabusService } from '../../services/syllabus.service';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-profile-page',
@@ -28,7 +29,8 @@ export class ProfilePageComponent implements OnInit {
     private firestore: Firestore,
     public auth: AuthService,
     private appState: AppStateService,
-    private syllabusService: SyllabusService
+    private syllabusService: SyllabusService,
+    private router: Router
   ) {}
 
   ngOnInit(): void {
@@ -78,5 +80,12 @@ export class ProfilePageComponent implements OnInit {
         }
       }, { merge: true });
     }
+  }
+
+  async logout() {
+    await this.auth.logout();
+    this.appState.setBoard('');
+    this.appState.setStandard('');
+    await this.router.navigate(['/onboarding']);
   }
 }

--- a/Orynth/src/app/services/auth.service.ts
+++ b/Orynth/src/app/services/auth.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Auth, signInAnonymously, User, authState, linkWithPopup, GoogleAuthProvider, linkWithPhoneNumber, signInWithPopup } from '@angular/fire/auth';
+import { Auth, signInAnonymously, User, authState, linkWithPopup, GoogleAuthProvider, linkWithPhoneNumber, signInWithPopup, signInWithCredential, signOut } from '@angular/fire/auth';
 import { Observable } from 'rxjs';
 import { Firestore, doc, setDoc } from '@angular/fire/firestore';
 
@@ -46,12 +46,22 @@ export class AuthService {
       return cred;
     } catch (err: any) {
       if (err.code === 'auth/credential-already-in-use') {
-        const cred = await signInWithPopup(this.auth, new GoogleAuthProvider());
+        const credential = GoogleAuthProvider.credentialFromError(err);
+        let cred;
+        if (credential) {
+          cred = await signInWithCredential(this.auth, credential);
+        } else {
+          cred = await signInWithPopup(this.auth, new GoogleAuthProvider());
+        }
         await this.saveUserInfo(cred.user);
         return cred;
       }
       throw err;
     }
+  }
+
+  async logout() {
+    await signOut(this.auth);
   }
 
   async upgradeWithPhoneNumber(phoneNumber: string, appVerifier: any) {


### PR DESCRIPTION
## Summary
- add single-popup Google login and logout helper
- redirect to subject list when auth state is restored
- show logout button on profile page
- auto redirect from login page when already authenticated

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686b8f6111dc832eb4d7d6ed535605cd