### PR TITLE
Fix Google login error when user isn't ready

### DIFF
--- a/Orynth/src/app/services/auth.service.ts
+++ b/Orynth/src/app/services/auth.service.ts
@@ -39,9 +39,10 @@ export class AuthService {
   }
 
   async upgradeWithGoogle() {
-    if (!this.auth.currentUser) throw new Error('No current user');
+    const user = await this.signInAnonymouslyIfNeeded();
+    if (!user) throw new Error('No current user');
     try {
-      const cred = await linkWithPopup(this.auth.currentUser, new GoogleAuthProvider());
+      const cred = await linkWithPopup(user, new GoogleAuthProvider());
       await this.saveUserInfo(cred.user);
       return cred;
     } catch (err: any) {


### PR DESCRIPTION
## Summary
- handle missing user in `upgradeWithGoogle`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686bb3448904832e9ae1e3d6d8c6cdeb