### PR TITLE
Simplify auth service auto login

### DIFF
--- a/Orynth/src/app/app.ts
+++ b/Orynth/src/app/app.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { AuthService } from './services/auth.service';
 
@@ -9,12 +9,8 @@ import { AuthService } from './services/auth.service';
   templateUrl: './app.html',
   styleUrl: './app.scss'
 })
-export class App implements OnInit {
+export class App {
   protected title = 'Orynth';
 
   constructor(private auth: AuthService) {}
-
-  ngOnInit(): void {
-    this.auth.signInAnonymouslyIfNeeded();
-  }
 }


### PR DESCRIPTION
## Summary
- remove manual anonymous login handling
- ensure AuthService signs in anonymously once and exposes state
- cleanup unused lifecycle hook

## Testing
- `npm ci`
- `npx ng build`

------
https://chatgpt.com/codex/tasks/task_e_686bce144a38832e80ccd8800b93f87a