### PR TITLE
Simplify auth Google login

### DIFF
--- a/Orynth/src/app/app.ts
+++ b/Orynth/src/app/app.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { AuthService } from './services/auth.service';
 
@@ -9,12 +9,8 @@ import { AuthService } from './services/auth.service';
   templateUrl: './app.html',
   styleUrl: './app.scss'
 })
-export class App implements OnInit {
+export class App {
   protected title = 'Orynth';
 
   constructor(private auth: AuthService) {}
-
-  ngOnInit(): void {
-    this.auth.signInAnonymouslyIfNeeded();
-  }
 }

--- a/Orynth/src/app/pages/login/login-page.ts
+++ b/Orynth/src/app/pages/login/login-page.ts
@@ -22,7 +22,7 @@ export class LoginPageComponent implements OnInit {
   }
 
   async loginWithGoogle() {
-    await this.auth.upgradeWithGoogle();
+    await this.auth.loginWithGoogle();
     await this.router.navigate(['/subject-list']);
   }
 }

--- a/Orynth/src/app/services/auth.service.ts
+++ b/Orynth/src/app/services/auth.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
-import { Auth, signInAnonymously, User, authState, linkWithPopup, GoogleAuthProvider, linkWithPhoneNumber, signInWithPopup, signInWithCredential, signOut } from '@angular/fire/auth';
-import { Observable } from 'rxjs';
+import { Auth, signInAnonymously, User, authState, GoogleAuthProvider, linkWithPhoneNumber, signInWithPopup, signOut } from '@angular/fire/auth';
+import { Observable, take } from 'rxjs';
 import { Firestore, doc, setDoc } from '@angular/fire/firestore';
 
 @Injectable({
@@ -11,19 +11,13 @@ export class AuthService {
 
   constructor(private auth: Auth, private firestore: Firestore) {
     this.authState$ = authState(this.auth);
-  }
-
-  async signInAnonymouslyIfNeeded(): Promise<User | null> {
-    if (this.auth.currentUser) {
-      return this.auth.currentUser;
-    }
-    try {
-      const cred = await signInAnonymously(this.auth);
-      return cred.user;
-    } catch (error) {
-      console.error('Anonymous sign-in failed', error);
-      return this.auth.currentUser ?? null;
-    }
+    this.authState$.pipe(take(1)).subscribe(user => {
+      if (!user) {
+        signInAnonymously(this.auth).catch(err => {
+          console.error('Anonymous sign-in failed', err);
+        });
+      }
+    });
   }
 
   getCurrentUserId(): string {
@@ -38,25 +32,13 @@ export class AuthService {
     return !!this.auth.currentUser && this.auth.currentUser.isAnonymous;
   }
 
-  async upgradeWithGoogle() {
-    const user = await this.signInAnonymouslyIfNeeded();
-    if (!user) throw new Error('No current user');
+  async loginWithGoogle() {
     try {
-      const cred = await linkWithPopup(user, new GoogleAuthProvider());
+      const cred = await signInWithPopup(this.auth, new GoogleAuthProvider());
       await this.saveUserInfo(cred.user);
       return cred;
-    } catch (err: any) {
-      if (err.code === 'auth/credential-already-in-use') {
-        const credential = GoogleAuthProvider.credentialFromError(err);
-        let cred;
-        if (credential) {
-          cred = await signInWithCredential(this.auth, credential);
-        } else {
-          cred = await signInWithPopup(this.auth, new GoogleAuthProvider());
-        }
-        await this.saveUserInfo(cred.user);
-        return cred;
-      }
+    } catch (err) {
+      console.error('Google sign-in failed', err);
       throw err;
     }
   }


### PR DESCRIPTION
## Summary
- sign in anonymously automatically in AuthService
- drop upgrade flow and add simple `loginWithGoogle`
- update login page to use the new method

## Testing
- `npm ci`
- `npm run build` *(with Angular warnings)*

------
https://chatgpt.com/codex/tasks/task_e_686bce144a38832e80ccd8800b93f87a