### PR TITLE
Add direct Google sign-in

### DIFF
--- a/Orynth/src/app/pages/login/login-page.ts
+++ b/Orynth/src/app/pages/login/login-page.ts
@@ -22,7 +22,7 @@ export class LoginPageComponent implements OnInit {
   }
 
   async loginWithGoogle() {
-    await this.auth.upgradeWithGoogle();
+    await this.auth.loginWithGoogle();
     await this.router.navigate(['/subject-list']);
   }
 }

--- a/Orynth/src/app/services/auth.service.ts
+++ b/Orynth/src/app/services/auth.service.ts
@@ -32,6 +32,17 @@ export class AuthService {
     return !!this.auth.currentUser && this.auth.currentUser.isAnonymous;
   }
 
+  async loginWithGoogle() {
+    try {
+      const cred = await signInWithPopup(this.auth, new GoogleAuthProvider());
+      await this.saveUserInfo(cred.user);
+      return cred;
+    } catch (err) {
+      console.error('Google sign-in failed', err);
+      throw err;
+    }
+  }
+
   async upgradeWithGoogle() {
     const user = this.auth.currentUser;
     if (!user) throw new Error('No current user');


### PR DESCRIPTION
## Summary
- implement `loginWithGoogle()` in `AuthService`
- use new method in `LoginPageComponent`

## Testing
- `npm ci`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686bdc5015e4832ea5ebece43b03f33f