### PR TITLE
Add chapter test results feature

### DIFF
--- a/Orynth/src/app/app.routes.ts
+++ b/Orynth/src/app/app.routes.ts
@@ -32,6 +32,10 @@ export const routes: Routes = [
     loadComponent: () => import('./pages/login/login-page').then(m => m.LoginPageComponent)
   },
   {
+    path: 'add-test-results',
+    loadComponent: () => import('./pages/add-test-results/add-test-results-page').then(m => m.AddTestResultsPageComponent)
+  },
+  {
     path: 'firebase-test',
     loadComponent: () => import('./components/firebase-test/firebase-test.component').then(m => m.FirebaseTestComponent)
   },

--- a/Orynth/src/app/pages/add-test-results/add-test-results-page.html
+++ b/Orynth/src/app/pages/add-test-results/add-test-results-page.html
@@ -1,0 +1,51 @@
+<div class="min-h-screen bg-gradient-to-br from-blue-50 to-green-50 page-wrapper">
+  <div class="bg-white/90 backdrop-blur-sm sticky top-0 z-10 border-b border-gray-200">
+    <div class="flex items-center justify-between p-4">
+      <a routerLink="/chapter-tracker" class="p-2 hover:bg-gray-100 rounded-full tap-highlight">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-6 h-6 text-gray-700">
+          <polyline points="15 18 9 12 15 6"></polyline>
+        </svg>
+      </a>
+      <h1 class="text-lg font-semibold text-gray-900">Add Test Result</h1>
+      <div class="w-6"></div>
+    </div>
+  </div>
+
+  <div class="px-6 pt-6 pb-8">
+    <div class="max-w-sm mx-auto space-y-6">
+      <div class="bg-white rounded-xl p-6 card-shadow space-y-4 animate-fade-in">
+        <div>
+          <label class="text-sm font-medium text-gray-900">Test Type</label>
+          <select [(ngModel)]="testType" class="w-full h-12 bg-gray-50 rounded-xl border-gray-200 mt-1">
+            <option value="Test">Test</option>
+            <option value="Exam">Exam</option>
+            <option value="Practice">Practice</option>
+          </select>
+        </div>
+        <div>
+          <label class="text-sm font-medium text-gray-900">Total Marks</label>
+          <input type="number" [(ngModel)]="totalMarks" class="w-full h-12 bg-gray-50 rounded-xl border-gray-200 mt-1" />
+        </div>
+        <div>
+          <label class="text-sm font-medium text-gray-900">Marks Achieved</label>
+          <input type="number" [(ngModel)]="marksAchieved" class="w-full h-12 bg-gray-50 rounded-xl border-gray-200 mt-1" />
+        </div>
+        <button (click)="save()" class="w-full h-12 text-lg font-semibold bg-primary hover:bg-primary/90 text-white rounded-xl card-shadow hover:card-shadow-hover tap-highlight">Save</button>
+      </div>
+
+      <div class="bg-white rounded-xl p-4 card-shadow animate-fade-in" *ngIf="(results$ | async) as results">
+        <h2 class="text-lg font-semibold text-gray-900 mb-3">Previous Entries</h2>
+        <div *ngIf="results.length; else noRes" class="space-y-2">
+          <div *ngFor="let r of results" class="flex justify-between text-sm">
+            <div>{{ r.type }} - {{ r.chapter }}</div>
+            <div>{{ r.marksAchieved }}/{{ r.totalMarks }}</div>
+          </div>
+        </div>
+        <ng-template #noRes>
+          <p class="text-gray-600 text-sm">No entries yet.</p>
+        </ng-template>
+      </div>
+    </div>
+  </div>
+</div>
+<app-bottom-nav></app-bottom-nav>

--- a/Orynth/src/app/pages/add-test-results/add-test-results-page.spec.ts
+++ b/Orynth/src/app/pages/add-test-results/add-test-results-page.spec.ts
@@ -1,0 +1,25 @@
+import { TestBed } from '@angular/core/testing';
+import { AddTestResultsPageComponent } from './add-test-results-page';
+import { TestResultsService } from '../../services/test-results.service';
+import { of } from 'rxjs';
+import { AppStateService } from '../../services/app-state.service';
+import { Router } from '@angular/router';
+
+describe('AddTestResultsPageComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AddTestResultsPageComponent],
+      providers: [
+        { provide: TestResultsService, useValue: { getTestResults: () => of([]), addTestResult: () => Promise.resolve() } },
+        { provide: AppStateService, useValue: { getChapter: () => 'Chap', setChapter: () => {} } },
+        { provide: Router, useValue: { navigate: () => {} } }
+      ]
+    }).compileComponents();
+  });
+
+  it('should create', () => {
+    const fixture = TestBed.createComponent(AddTestResultsPageComponent);
+    const component = fixture.componentInstance;
+    expect(component).toBeTruthy();
+  });
+});

--- a/Orynth/src/app/pages/add-test-results/add-test-results-page.ts
+++ b/Orynth/src/app/pages/add-test-results/add-test-results-page.ts
@@ -1,0 +1,48 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { RouterModule, Router } from '@angular/router';
+import { BottomNavComponent } from '../../components/bottom-nav/bottom-nav';
+import { TestResultsService } from '../../services/test-results.service';
+import { AppStateService } from '../../services/app-state.service';
+import { Observable } from 'rxjs';
+
+@Component({
+  selector: 'app-add-test-results-page',
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterModule, BottomNavComponent],
+  templateUrl: './add-test-results-page.html'
+})
+export class AddTestResultsPageComponent implements OnInit {
+  testType: 'Test' | 'Exam' | 'Practice' = 'Test';
+  totalMarks: number | null = null;
+  marksAchieved: number | null = null;
+  chapter = '';
+  results$!: Observable<any>;
+
+  constructor(
+    private router: Router,
+    private testResultsService: TestResultsService,
+    private appState: AppStateService
+  ) {
+    this.results$ = this.testResultsService.getTestResults();
+  }
+
+  ngOnInit(): void {
+    this.chapter = this.appState.getChapter();
+  }
+
+  async save() {
+    if (this.totalMarks === null || this.marksAchieved === null) {
+      return;
+    }
+    await this.testResultsService.addTestResult({
+      chapter: this.chapter,
+      type: this.testType,
+      totalMarks: this.totalMarks,
+      marksAchieved: this.marksAchieved,
+      date: new Date().toISOString()
+    });
+    this.router.navigate(['/chapter-tracker']);
+  }
+}

--- a/Orynth/src/app/pages/chapter-tracker/chapter-tracker-page.html
+++ b/Orynth/src/app/pages/chapter-tracker/chapter-tracker-page.html
@@ -28,11 +28,16 @@
         </div>
       </div>
 
-      <div class="space-y-3">
-        <div *ngFor="let c of chapters; index as i" class="bg-white rounded-xl p-4 card-shadow hover:card-shadow-hover transition-all animate-fade-in" [style.animationDelay]="(i * 0.05) + 's'">
-          <div class="flex items-center justify-between mb-3">
-            <h3 class="font-medium text-gray-900 flex-1 pr-4">{{ c.name }}</h3>
-          </div>
+        <div class="space-y-3">
+          <div *ngFor="let c of chapters; index as i" class="bg-white rounded-xl p-4 card-shadow hover:card-shadow-hover transition-all animate-fade-in" [style.animationDelay]="(i * 0.05) + 's'">
+            <div class="flex items-center justify-between mb-3">
+              <h3 class="font-medium text-gray-900 flex-1 pr-4">{{ c.name }}</h3>
+              <button (click)="addResult(c)" class="p-2 hover:bg-gray-100 rounded-full tap-highlight">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" class="w-5 h-5 text-gray-700">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M12 5v14m7-7H5" />
+                </svg>
+              </button>
+            </div>
           <div class="flex items-center justify-between">
             <div class="flex items-center space-x-3">
               <div class="text-xs text-gray-500 mb-1">Status</div>

--- a/Orynth/src/app/pages/chapter-tracker/chapter-tracker-page.ts
+++ b/Orynth/src/app/pages/chapter-tracker/chapter-tracker-page.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { RouterModule } from '@angular/router';
+import { RouterModule, Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { ChipComponent } from '../../components/chip/chip';
 import { AppStateService } from '../../services/app-state.service';
@@ -31,7 +31,8 @@ export class ChapterTrackerPageComponent implements OnInit, OnDestroy {
     private appState: AppStateService,
     private syllabusService: SyllabusService,
     private progressService: ProgressService,
-    public auth: AuthService
+    public auth: AuthService,
+    private router: Router
   ) {
     this.subject = this.appState.getSubject();
   }
@@ -87,6 +88,11 @@ export class ChapterTrackerPageComponent implements OnInit, OnDestroy {
     const idx = cycle.indexOf(chapter.status);
     chapter.status = cycle[(idx + 1) % cycle.length];
     this.saveProgress();
+  }
+
+  addResult(chapter: any) {
+    this.appState.setChapter(chapter.name);
+    this.router.navigate(['/add-test-results']);
   }
 
   saveProgress() {

--- a/Orynth/src/app/services/app-state.service.ts
+++ b/Orynth/src/app/services/app-state.service.ts
@@ -5,6 +5,7 @@ export class AppStateService {
   private board = '';
   private standard = '';
   private subject = '';
+  private chapter = '';
 
   setBoard(value: string) {
     this.board = value;
@@ -28,5 +29,13 @@ export class AppStateService {
 
   getSubject(): string {
     return this.subject;
+  }
+
+  setChapter(value: string) {
+    this.chapter = value;
+  }
+
+  getChapter(): string {
+    return this.chapter;
   }
 }

--- a/Orynth/src/app/services/test-results.service.ts
+++ b/Orynth/src/app/services/test-results.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@angular/core';
+import { Firestore, doc, setDoc, docData, arrayUnion } from '@angular/fire/firestore';
+import { AuthService } from './auth.service';
+import { Observable, map } from 'rxjs';
+
+export interface TestResult {
+  chapter: string;
+  type: 'Test' | 'Exam' | 'Practice';
+  totalMarks: number;
+  marksAchieved: number;
+  date: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class TestResultsService {
+  constructor(private firestore: Firestore, private auth: AuthService) {}
+
+  async addTestResult(result: TestResult) {
+    if (!this.auth.isLoggedIn()) {
+      return;
+    }
+    const uid = this.auth.getCurrentUserId();
+    const ref = doc(this.firestore, `Users/${uid}`);
+    await setDoc(ref, { testResults: arrayUnion(result) }, { merge: true });
+  }
+
+  getTestResults(): Observable<TestResult[]> {
+    const uid = this.auth.getCurrentUserId();
+    const ref = doc(this.firestore, `Users/${uid}`);
+    return docData(ref).pipe(map(d => (d as any)?.testResults ?? []));
+  }
+}


### PR DESCRIPTION
## Summary
- add ability to store current chapter in AppStateService
- show add button on chapter tracker page
- create Add Test Results page with form to store marks
- add TestResultsService to save results in Firestore
- wire new route `/add-test-results`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686e134f8484832e9b7087f72c9fa1eb