### PR TITLE
Add test results entry page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,9 @@ npm run build
 If the build fails, fix the issue before committing.
 Report the result of the build in the Testing section of your pull request message.
 
+Increment the version displayed in `bottom-nav.html` with each commit unless a
+prompt specifies a different version.
+
 Firestore reads and writes must target a document path with an **even number of segments**. The main user document lives at `Users/{uid}`. Store all related data (basic info, profile details and syllabus progress) inside that document as nested objects:
 
 ```

--- a/Orynth/package-lock.json
+++ b/Orynth/package-lock.json
@@ -13,6 +13,7 @@
         "@angular/core": "^20.0.0",
         "@angular/fire": "^20.0.1",
         "@angular/forms": "^20.0.0",
+        "@angular/material": "^20.1.0",
         "@angular/platform-browser": "^20.0.0",
         "@angular/router": "^20.0.0",
         "@angular/service-worker": "^20.0.5",
@@ -218,6 +219,22 @@
         "vitest": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@angular/cdk": {
+      "version": "20.1.0",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-20.1.0.tgz",
+      "integrity": "sha512-JhgbSOv7xZqWNZjuCh8A3A7pGv0mhtmGjHo36157LrxRO6R7x2yJJjxC5nQeroKZWhgN+X/jG/EJlzEvl9PxTw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "parse5": "^7.1.2",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^20.0.0 || ^21.0.0",
+        "@angular/core": "^20.0.0 || ^21.0.0",
+        "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/cli": {
@@ -480,6 +497,23 @@
         "@angular/common": "20.0.5",
         "@angular/core": "20.0.5",
         "@angular/platform-browser": "20.0.5",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
+    "node_modules/@angular/material": {
+      "version": "20.1.0",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-20.1.0.tgz",
+      "integrity": "sha512-LfGz/V/kZwRIhzIZBiurM4Wc5CQiiJkiOChUfoEOvQLN2hckPFZbbvtg6JwxxA6nhzsDhuGHbj7Xj5dNsLfZLw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/cdk": "20.1.0",
+        "@angular/common": "^20.0.0 || ^21.0.0",
+        "@angular/core": "^20.0.0 || ^21.0.0",
+        "@angular/forms": "^20.0.0 || ^21.0.0",
+        "@angular/platform-browser": "^20.0.0 || ^21.0.0",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -7873,7 +7907,6 @@
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
       "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "dev": true,
       "dependencies": {
         "entities": "^6.0.0"
       },
@@ -7923,7 +7956,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
       "engines": {
         "node": ">=0.12"
       },

--- a/Orynth/package.json
+++ b/Orynth/package.json
@@ -25,6 +25,7 @@
     "@angular/core": "^20.0.0",
     "@angular/fire": "^20.0.1",
     "@angular/forms": "^20.0.0",
+    "@angular/material": "^20.1.0",
     "@angular/platform-browser": "^20.0.0",
     "@angular/router": "^20.0.0",
     "@angular/service-worker": "^20.0.5",

--- a/Orynth/src/app/app.config.ts
+++ b/Orynth/src/app/app.config.ts
@@ -1,4 +1,4 @@
-import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
+import { ApplicationConfig, importProvidersFrom, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
 import { provideServiceWorker } from '@angular/service-worker';
 import { provideRouter } from '@angular/router';
@@ -15,6 +15,7 @@ import { getApp } from 'firebase/app';
 import { environment } from '../environments/environment';
 
 import { routes } from './app.routes';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 
 let firestoreInstance: ReturnType<typeof initializeFirestore> | undefined;
 
@@ -63,6 +64,7 @@ export const appConfig: ApplicationConfig = {
         popupRedirectResolver: browserPopupRedirectResolver
       });
     }),
-    provideFirestore(() => firestoreFactory())
+    provideFirestore(() => firestoreFactory()),
+    importProvidersFrom(MatSnackBarModule)
   ]
 };

--- a/Orynth/src/app/app.routes.ts
+++ b/Orynth/src/app/app.routes.ts
@@ -35,4 +35,8 @@ export const routes: Routes = [
     path: 'firebase-test',
     loadComponent: () => import('./components/firebase-test/firebase-test.component').then(m => m.FirebaseTestComponent)
   },
+  {
+    path: 'add-test-results',
+    loadComponent: () => import('./pages/add-test-results/add-test-results-page').then(m => m.AddTestResultsPageComponent)
+  },
 ];

--- a/Orynth/src/app/app.routes.ts
+++ b/Orynth/src/app/app.routes.ts
@@ -39,4 +39,8 @@ export const routes: Routes = [
     path: 'add-test-results',
     loadComponent: () => import('./pages/add-test-results/add-test-results-page').then(m => m.AddTestResultsPageComponent)
   },
+  {
+    path: 'logs',
+    loadComponent: () => import('./pages/logs/logs-page').then(m => m.LogsPageComponent)
+  },
 ];

--- a/Orynth/src/app/app.ts
+++ b/Orynth/src/app/app.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { AuthService } from './services/auth.service';
+import { LogService } from './services/log.service';
 
 @Component({
   selector: 'app-root',
@@ -12,5 +13,5 @@ import { AuthService } from './services/auth.service';
 export class App {
   protected title = 'Orynth';
 
-  constructor(private auth: AuthService) {}
+  constructor(private auth: AuthService, _logs: LogService) {}
 }

--- a/Orynth/src/app/components/bottom-nav/bottom-nav.html
+++ b/Orynth/src/app/components/bottom-nav/bottom-nav.html
@@ -22,7 +22,8 @@
   <div class="text-center pt-2 border-t border-gray-100 mt-3">
     <p class="text-xs text-gray-500">
       Powered by Growth Tutorials -
-      <a routerLink="/logs" class="underline tap-highlight">Logs</a> - v0.0.1
+      <a routerLink="/logs" class="underline tap-highlight">Logs</a> -
+      <span (click)="reloadApp()" class="underline cursor-pointer tap-highlight">v0.0.2</span>
     </p>
   </div>
 </div>

--- a/Orynth/src/app/components/bottom-nav/bottom-nav.html
+++ b/Orynth/src/app/components/bottom-nav/bottom-nav.html
@@ -23,7 +23,7 @@
     <p class="text-xs text-gray-500">
       Powered by Growth Tutorials -
       <a routerLink="/logs" class="underline tap-highlight">Logs</a> -
-      <span (click)="reloadApp()" class="underline cursor-pointer tap-highlight">v0.0.3</span>
+      <span (click)="reloadApp()" class="underline cursor-pointer tap-highlight">v0.0.4</span>
     </p>
   </div>
 </div>

--- a/Orynth/src/app/components/bottom-nav/bottom-nav.html
+++ b/Orynth/src/app/components/bottom-nav/bottom-nav.html
@@ -20,6 +20,9 @@
     </a>
   </div>
   <div class="text-center pt-2 border-t border-gray-100 mt-3">
-    <p class="text-xs text-gray-500">Powered by Growth Tutorials</p>
+    <p class="text-xs text-gray-500">
+      Powered by Growth Tutorials -
+      <a routerLink="/logs" class="underline tap-highlight">Logs</a> - v0.0.1
+    </p>
   </div>
 </div>

--- a/Orynth/src/app/components/bottom-nav/bottom-nav.html
+++ b/Orynth/src/app/components/bottom-nav/bottom-nav.html
@@ -23,7 +23,7 @@
     <p class="text-xs text-gray-500">
       Powered by Growth Tutorials -
       <a routerLink="/logs" class="underline tap-highlight">Logs</a> -
-      <span (click)="reloadApp()" class="underline cursor-pointer tap-highlight">v0.0.2</span>
+      <span (click)="reloadApp()" class="underline cursor-pointer tap-highlight">v0.0.3</span>
     </p>
   </div>
 </div>

--- a/Orynth/src/app/components/bottom-nav/bottom-nav.html
+++ b/Orynth/src/app/components/bottom-nav/bottom-nav.html
@@ -23,7 +23,7 @@
     <p class="text-xs text-gray-500">
       Powered by Growth Tutorials -
       <a routerLink="/logs" class="underline tap-highlight">Logs</a> -
-      <span (click)="reloadApp()" class="underline cursor-pointer tap-highlight">v0.0.4</span>
+      <span (click)="reloadApp()" class="underline cursor-pointer tap-highlight">v0.0.5</span>
     </p>
   </div>
 </div>

--- a/Orynth/src/app/components/bottom-nav/bottom-nav.ts
+++ b/Orynth/src/app/components/bottom-nav/bottom-nav.ts
@@ -9,4 +9,15 @@ import { RouterModule } from '@angular/router';
   templateUrl: './bottom-nav.html',
   styleUrl: './bottom-nav.scss'
 })
-export class BottomNavComponent {}
+export class BottomNavComponent {
+  reloadApp() {
+    if ('caches' in globalThis) {
+      caches
+        .keys()
+        .then(keys => Promise.all(keys.map(k => caches.delete(k))))
+        .finally(() => globalThis.location.reload());
+    } else {
+      globalThis.location.reload();
+    }
+  }
+}

--- a/Orynth/src/app/components/unsynced-notice/unsynced-notice.ts
+++ b/Orynth/src/app/components/unsynced-notice/unsynced-notice.ts
@@ -1,12 +1,13 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
 import { Auth } from '@angular/fire/auth';
 import { AuthService } from '../../services/auth.service';
 
 @Component({
   selector: 'app-unsynced-notice',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, RouterModule],
   templateUrl: './unsynced-notice.html',
   styleUrl: './unsynced-notice.scss'
 })
@@ -14,7 +15,7 @@ export class UnsyncedNoticeComponent {
   show = false;
   constructor(private auth: Auth, private authService: AuthService) {
     this.authService.authState$.subscribe(u => {
-      this.show = !u;
+      this.show = !u || u.isAnonymous;
     });
   }
 }

--- a/Orynth/src/app/pages/add-test-results/add-test-results-page.html
+++ b/Orynth/src/app/pages/add-test-results/add-test-results-page.html
@@ -1,0 +1,50 @@
+<div class="min-h-screen bg-gradient-to-br from-blue-50 to-green-50 page-wrapper">
+  <div class="bg-white/90 backdrop-blur-sm sticky top-0 z-10 border-b border-gray-200">
+    <div class="flex items-center justify-between p-4">
+      <button (click)="goBack()" class="p-2 hover:bg-gray-100 rounded-full tap-highlight">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-6 h-6 text-gray-700">
+          <polyline points="15 18 9 12 15 6"></polyline>
+        </svg>
+      </button>
+      <h1 class="text-lg font-semibold text-gray-900">{{ chapter }}</h1>
+      <div class="w-10"></div>
+    </div>
+  </div>
+
+  <div class="px-6 pt-6 pb-8">
+    <div class="max-w-sm mx-auto space-y-6">
+      <div class="bg-white rounded-xl p-6 card-shadow">
+        <div class="space-y-4">
+          <div>
+            <label class="text-sm font-medium text-gray-900">Test Type</label>
+            <select [(ngModel)]="testType" class="w-full h-12 bg-gray-50 rounded-xl border-gray-200 mt-1">
+              <option value="Test">Test</option>
+              <option value="Exam">Exam</option>
+              <option value="Practice">Practice</option>
+            </select>
+          </div>
+          <div>
+            <label class="text-sm font-medium text-gray-900">Total Marks</label>
+            <input type="number" [(ngModel)]="totalMarks" class="w-full h-12 bg-gray-50 rounded-xl border-gray-200 mt-1" />
+          </div>
+          <div>
+            <label class="text-sm font-medium text-gray-900">Marks Achieved</label>
+            <input type="number" [(ngModel)]="marksAchieved" class="w-full h-12 bg-gray-50 rounded-xl border-gray-200 mt-1" />
+          </div>
+          <button (click)="save()" class="w-full h-12 bg-primary text-white rounded-xl">Save Result</button>
+        </div>
+      </div>
+
+      <div class="bg-white rounded-xl p-6 card-shadow" *ngIf="results.length > 0">
+        <h2 class="text-lg font-semibold text-gray-900 mb-4">Previous Entries</h2>
+        <div class="space-y-2">
+          <div *ngFor="let r of results" class="flex justify-between text-sm">
+            <div>{{ r.testType }} - {{ r.marksAchieved }}/{{ r.totalMarks }}</div>
+            <div class="text-gray-500">{{ r.timestamp | date:'shortDate' }}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<app-bottom-nav></app-bottom-nav>

--- a/Orynth/src/app/pages/add-test-results/add-test-results-page.scss
+++ b/Orynth/src/app/pages/add-test-results/add-test-results-page.scss
@@ -1,0 +1,1 @@
+/* minimal additional styling if needed */

--- a/Orynth/src/app/pages/add-test-results/add-test-results-page.ts
+++ b/Orynth/src/app/pages/add-test-results/add-test-results-page.ts
@@ -1,0 +1,60 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Router, RouterModule } from '@angular/router';
+import { TestResultsService } from '../../services/test-results.service';
+import { AppStateService } from '../../services/app-state.service';
+import { BottomNavComponent } from '../../components/bottom-nav/bottom-nav';
+
+@Component({
+  selector: 'app-add-test-results-page',
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterModule, BottomNavComponent],
+  templateUrl: './add-test-results-page.html',
+  styleUrl: './add-test-results-page.scss'
+})
+export class AddTestResultsPageComponent implements OnInit {
+  chapter = '';
+  subject = '';
+  testType = 'Test';
+  totalMarks: number | null = null;
+  marksAchieved: number | null = null;
+  results: any[] = [];
+
+  constructor(
+    private router: Router,
+    private testResults: TestResultsService,
+    private appState: AppStateService
+  ) {}
+
+  ngOnInit(): void {
+    const nav = this.router.getCurrentNavigation();
+    this.chapter = nav?.extras.state?.['chapter'] || '';
+    this.subject = this.appState.getSubject();
+    this.loadResults();
+  }
+
+  async loadResults() {
+    this.testResults.getResults(this.subject, this.chapter).subscribe(r => {
+      this.results = Array.isArray(r) ? r : [];
+    });
+  }
+
+  async save() {
+    if (this.totalMarks == null || this.marksAchieved == null) return;
+    const entry = {
+      testType: this.testType,
+      totalMarks: this.totalMarks,
+      marksAchieved: this.marksAchieved,
+      timestamp: new Date().toISOString()
+    };
+    await this.testResults.addResult(this.subject, this.chapter, entry);
+    this.totalMarks = null;
+    this.marksAchieved = null;
+    this.loadResults();
+  }
+
+  goBack() {
+    this.router.navigate(['/chapter-tracker']);
+  }
+}

--- a/Orynth/src/app/pages/chapter-tracker/chapter-tracker-page.html
+++ b/Orynth/src/app/pages/chapter-tracker/chapter-tracker-page.html
@@ -32,6 +32,12 @@
         <div *ngFor="let c of chapters; index as i" class="bg-white rounded-xl p-4 card-shadow hover:card-shadow-hover transition-all animate-fade-in" [style.animationDelay]="(i * 0.05) + 's'">
           <div class="flex items-center justify-between mb-3">
             <h3 class="font-medium text-gray-900 flex-1 pr-4">{{ c.name }}</h3>
+            <button (click)="addResults(c)" class="p-2 hover:bg-gray-100 rounded-full">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-5 h-5 text-gray-700">
+                <line x1="12" y1="5" x2="12" y2="19"></line>
+                <line x1="5" y1="12" x2="19" y2="12"></line>
+              </svg>
+            </button>
           </div>
           <div class="flex items-center justify-between">
             <div class="flex items-center space-x-3">

--- a/Orynth/src/app/pages/chapter-tracker/chapter-tracker-page.ts
+++ b/Orynth/src/app/pages/chapter-tracker/chapter-tracker-page.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { RouterModule } from '@angular/router';
+import { RouterModule, Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { ChipComponent } from '../../components/chip/chip';
 import { AppStateService } from '../../services/app-state.service';
@@ -31,7 +31,8 @@ export class ChapterTrackerPageComponent implements OnInit, OnDestroy {
     private appState: AppStateService,
     private syllabusService: SyllabusService,
     private progressService: ProgressService,
-    public auth: AuthService
+    public auth: AuthService,
+    private router: Router
   ) {
     this.subject = this.appState.getSubject();
   }
@@ -101,6 +102,10 @@ export class ChapterTrackerPageComponent implements OnInit, OnDestroy {
       }
     });
     this.progressService.setAllProgress(progress);
+  }
+
+  addResults(chapter: any) {
+    this.router.navigate(['/add-test-results'], { state: { chapter: chapter.name } });
   }
 
   getStatusLabel(status: string): string {

--- a/Orynth/src/app/pages/logs/logs-page.html
+++ b/Orynth/src/app/pages/logs/logs-page.html
@@ -14,7 +14,7 @@
   <div class="p-4">
     <mat-list>
       <mat-list-item *ngFor="let l of logs$ | async" class="log-item">
-        <div matLine class="log-line">{{ l.timestamp | date:'short' }}: {{ l.message }}</div>
+        <span matLine class="log-line">{{ l.timestamp | date:'short' }}: {{ l.message }}</span>
       </mat-list-item>
     </mat-list>
   </div>

--- a/Orynth/src/app/pages/logs/logs-page.html
+++ b/Orynth/src/app/pages/logs/logs-page.html
@@ -15,7 +15,7 @@
     <mat-list>
       <mat-list-item *ngFor="let l of logs$ | async" class="log-item">
         <div matLine class="log-line">
-          <span class="timestamp">{{ l.timestamp | date:'short' }}:</span>
+          <span class="timestamp mr-1">{{ l.timestamp | date:'short' }}:</span>
           <span class="message">{{ l.message }}</span>
         </div>
       </mat-list-item>

--- a/Orynth/src/app/pages/logs/logs-page.html
+++ b/Orynth/src/app/pages/logs/logs-page.html
@@ -1,0 +1,23 @@
+<div class="min-h-screen bg-gradient-to-br from-blue-50 to-green-50 page-wrapper">
+  <div class="bg-white/90 backdrop-blur-sm sticky top-0 z-10 border-b border-gray-200">
+    <div class="flex items-center justify-between p-4">
+      <button (click)="goBack()" class="p-2 hover:bg-gray-100 rounded-full tap-highlight">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-6 h-6 text-gray-700">
+          <polyline points="15 18 9 12 15 6"></polyline>
+        </svg>
+      </button>
+      <h1 class="text-lg font-semibold text-gray-900">Logs</h1>
+      <div class="w-10"></div>
+    </div>
+  </div>
+
+  <div class="p-4">
+    <mat-list>
+      <mat-list-item *ngFor="let l of logs$ | async" class="break-words whitespace-pre-wrap">
+        <div matLine>{{ l.message }}</div>
+        <div matLine class="text-xs text-gray-500">{{ l.timestamp | date:'short' }}</div>
+      </mat-list-item>
+    </mat-list>
+  </div>
+</div>
+<app-bottom-nav></app-bottom-nav>

--- a/Orynth/src/app/pages/logs/logs-page.html
+++ b/Orynth/src/app/pages/logs/logs-page.html
@@ -14,7 +14,10 @@
   <div class="p-4">
     <mat-list>
       <mat-list-item *ngFor="let l of logs$ | async" class="log-item">
-        <span matLine class="log-line">{{ l.timestamp | date:'short' }}: {{ l.message }}</span>
+        <div matLine class="log-line">
+          <span class="timestamp">{{ l.timestamp | date:'short' }}:</span>
+          <span class="message">{{ l.message }}</span>
+        </div>
       </mat-list-item>
     </mat-list>
   </div>

--- a/Orynth/src/app/pages/logs/logs-page.html
+++ b/Orynth/src/app/pages/logs/logs-page.html
@@ -13,8 +13,8 @@
 
   <div class="p-4">
     <mat-list>
-      <mat-list-item *ngFor="let l of logs$ | async" class="break-words whitespace-pre-wrap">
-        <div matLine>{{ l.timestamp | date:'short' }}: {{ l.message }}</div>
+      <mat-list-item *ngFor="let l of logs$ | async" class="log-item">
+        <div matLine class="log-line">{{ l.timestamp | date:'short' }}: {{ l.message }}</div>
       </mat-list-item>
     </mat-list>
   </div>

--- a/Orynth/src/app/pages/logs/logs-page.html
+++ b/Orynth/src/app/pages/logs/logs-page.html
@@ -14,8 +14,7 @@
   <div class="p-4">
     <mat-list>
       <mat-list-item *ngFor="let l of logs$ | async" class="break-words whitespace-pre-wrap">
-        <div matLine>{{ l.message }}</div>
-        <div matLine class="text-xs text-gray-500">{{ l.timestamp | date:'short' }}</div>
+        <div matLine>{{ l.timestamp | date:'short' }}: {{ l.message }}</div>
       </mat-list-item>
     </mat-list>
   </div>

--- a/Orynth/src/app/pages/logs/logs-page.html
+++ b/Orynth/src/app/pages/logs/logs-page.html
@@ -12,14 +12,12 @@
   </div>
 
   <div class="p-4">
-    <mat-list>
-      <mat-list-item *ngFor="let l of logs$ | async" class="log-item">
-        <div matLine class="log-line">
-          <span class="timestamp mr-1">{{ l.timestamp | date:'short' }}:</span>
-          <span class="message">{{ l.message }}</span>
-        </div>
-      </mat-list-item>
-    </mat-list>
+    <div class="log-container">
+      <div *ngFor="let l of logs$ | async" class="log-item">
+        <span class="timestamp">{{ l.timestamp | date:'short' }}:</span>
+        <span class="message">{{ l.message }}</span>
+      </div>
+    </div>
   </div>
 </div>
 <app-bottom-nav></app-bottom-nav>

--- a/Orynth/src/app/pages/logs/logs-page.scss
+++ b/Orynth/src/app/pages/logs/logs-page.scss
@@ -1,19 +1,22 @@
-mat-list {
+.log-container {
   @apply w-full bg-white rounded-xl card-shadow;
 }
 
-mat-list-item.log-item {
-  @apply px-3 py-2 border-b border-gray-200;
-  align-items: flex-start !important;
+.log-item {
+  @apply flex items-start text-left px-3 py-2 border-b border-gray-200 font-mono text-sm whitespace-pre-wrap break-words leading-snug;
+  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 
-mat-list-item:last-child {
+.log-item:last-child {
   @apply border-b-0;
 }
 
-mat-line.log-line {
-  @apply w-full font-mono text-sm break-words whitespace-pre-wrap text-left leading-snug;
-  word-break: break-word;
+.timestamp {
+  @apply mr-2 text-gray-500 flex-shrink-0;
+}
+
+.message {
+  @apply flex-1 break-words;
   overflow-wrap: anywhere;
-  display: block;
 }

--- a/Orynth/src/app/pages/logs/logs-page.scss
+++ b/Orynth/src/app/pages/logs/logs-page.scss
@@ -3,7 +3,7 @@ mat-list {
 }
 
 mat-list-item.log-item {
-  @apply flex flex-col items-start text-left px-2 pb-2 mb-2 border-b border-gray-200;
+  @apply flex flex-col items-start text-left px-2 py-2 mb-2 border-b border-gray-200;
   height: auto;
 }
 
@@ -12,5 +12,5 @@ mat-list-item.log-item:last-child {
 }
 
 mat-line.log-line {
-  @apply w-full break-words whitespace-pre-wrap font-mono leading-snug;
+  @apply w-full whitespace-pre-wrap break-all font-mono leading-snug;
 }

--- a/Orynth/src/app/pages/logs/logs-page.scss
+++ b/Orynth/src/app/pages/logs/logs-page.scss
@@ -2,10 +2,15 @@ mat-list {
   @apply w-full bg-white rounded-xl card-shadow;
 }
 
-mat-list-item {
-  @apply border-b border-gray-100 flex-col items-start px-2;
+mat-list-item.log-item {
+  @apply flex flex-col items-start text-left px-2 pb-2 mb-2 border-b border-gray-200;
+  height: auto;
 }
 
-mat-line {
-  @apply break-all whitespace-pre-wrap w-full leading-snug;
+mat-list-item.log-item:last-child {
+  @apply mb-0 border-b-0;
+}
+
+mat-line.log-line {
+  @apply w-full break-words whitespace-pre-wrap font-mono leading-snug;
 }

--- a/Orynth/src/app/pages/logs/logs-page.scss
+++ b/Orynth/src/app/pages/logs/logs-page.scss
@@ -3,5 +3,9 @@ mat-list {
 }
 
 mat-list-item {
-  @apply border-b border-gray-100;
+  @apply border-b border-gray-100 flex-col items-start;
+}
+
+mat-line {
+  @apply break-all whitespace-pre-wrap w-full leading-snug;
 }

--- a/Orynth/src/app/pages/logs/logs-page.scss
+++ b/Orynth/src/app/pages/logs/logs-page.scss
@@ -12,8 +12,8 @@ mat-list-item:last-child {
 }
 
 mat-line.log-line {
-  @apply w-full text-left font-mono text-sm break-words whitespace-pre-wrap leading-snug;
+  @apply w-full font-mono text-sm break-words whitespace-pre-wrap text-left leading-snug;
   word-break: break-word;
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
   display: block;
 }

--- a/Orynth/src/app/pages/logs/logs-page.scss
+++ b/Orynth/src/app/pages/logs/logs-page.scss
@@ -1,9 +1,9 @@
 mat-list {
-  @apply max-w-sm mx-auto bg-white rounded-xl card-shadow;
+  @apply w-full bg-white rounded-xl card-shadow;
 }
 
 mat-list-item {
-  @apply border-b border-gray-100 flex-col items-start;
+  @apply border-b border-gray-100 flex-col items-start px-2;
 }
 
 mat-line {

--- a/Orynth/src/app/pages/logs/logs-page.scss
+++ b/Orynth/src/app/pages/logs/logs-page.scss
@@ -3,14 +3,17 @@ mat-list {
 }
 
 mat-list-item.log-item {
-  @apply flex flex-col items-start text-left px-2 py-2 mb-2 border-b border-gray-200;
-  height: auto;
+  @apply px-3 py-2 border-b border-gray-200;
+  align-items: flex-start !important;
 }
 
-mat-list-item.log-item:last-child {
-  @apply mb-0 border-b-0;
+mat-list-item:last-child {
+  @apply border-b-0;
 }
 
 mat-line.log-line {
-  @apply w-full whitespace-pre-wrap break-all font-mono leading-snug;
+  @apply w-full text-left font-mono text-sm break-words whitespace-pre-wrap leading-snug;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  display: block;
 }

--- a/Orynth/src/app/pages/logs/logs-page.scss
+++ b/Orynth/src/app/pages/logs/logs-page.scss
@@ -1,0 +1,7 @@
+mat-list {
+  @apply max-w-sm mx-auto bg-white rounded-xl card-shadow;
+}
+
+mat-list-item {
+  @apply border-b border-gray-100;
+}

--- a/Orynth/src/app/pages/logs/logs-page.ts
+++ b/Orynth/src/app/pages/logs/logs-page.ts
@@ -1,0 +1,26 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Router } from '@angular/router';
+import { MatListModule } from '@angular/material/list';
+import { LogService, LogEntry } from '../../services/log.service';
+import { BottomNavComponent } from '../../components/bottom-nav/bottom-nav';
+import { Observable } from 'rxjs';
+
+@Component({
+  selector: 'app-logs-page',
+  standalone: true,
+  imports: [CommonModule, MatListModule, BottomNavComponent],
+  templateUrl: './logs-page.html',
+  styleUrl: './logs-page.scss'
+})
+export class LogsPageComponent {
+  logs$!: Observable<LogEntry[]>;
+
+  constructor(private router: Router, private logService: LogService) {
+    this.logs$ = this.logService.logs$;
+  }
+
+  goBack() {
+    this.router.navigate(['/subject-list']);
+  }
+}

--- a/Orynth/src/app/pages/logs/logs-page.ts
+++ b/Orynth/src/app/pages/logs/logs-page.ts
@@ -1,7 +1,6 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
-import { MatListModule } from '@angular/material/list';
 import { LogService, LogEntry } from '../../services/log.service';
 import { BottomNavComponent } from '../../components/bottom-nav/bottom-nav';
 import { Observable } from 'rxjs';
@@ -9,7 +8,7 @@ import { Observable } from 'rxjs';
 @Component({
   selector: 'app-logs-page',
   standalone: true,
-  imports: [CommonModule, MatListModule, BottomNavComponent],
+  imports: [CommonModule, BottomNavComponent],
   templateUrl: './logs-page.html',
   styleUrl: './logs-page.scss'
 })

--- a/Orynth/src/app/services/log.service.ts
+++ b/Orynth/src/app/services/log.service.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+export interface LogEntry {
+  level: 'log' | 'error' | 'warn';
+  message: string;
+  timestamp: Date;
+}
+
+@Injectable({ providedIn: 'root' })
+export class LogService {
+  private logsSubject = new BehaviorSubject<LogEntry[]>([]);
+  logs$ = this.logsSubject.asObservable();
+
+  constructor() {
+    const origLog = console.log.bind(console);
+    console.log = (...args: any[]) => {
+      this.add('log', args);
+      origLog(...args);
+    };
+
+    const origError = console.error.bind(console);
+    console.error = (...args: any[]) => {
+      this.add('error', args);
+      origError(...args);
+    };
+
+    const origWarn = console.warn.bind(console);
+    console.warn = (...args: any[]) => {
+      this.add('warn', args);
+      origWarn(...args);
+    };
+  }
+
+  private add(level: 'log' | 'error' | 'warn', args: any[]) {
+    const text = args.map(a => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ');
+    const entry: LogEntry = { level, message: text, timestamp: new Date() };
+    const current = this.logsSubject.value;
+    const updated = [...current, entry].slice(-200);
+    this.logsSubject.next(updated);
+  }
+}

--- a/Orynth/src/app/services/progress/progress.service.ts
+++ b/Orynth/src/app/services/progress/progress.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Firestore, doc, setDoc, docData } from '@angular/fire/firestore';
-import { Observable, map } from 'rxjs';
+import { Observable, map, of } from 'rxjs';
 import { AuthService } from '../auth.service';
 import { AppStateService } from '../app-state.service';
 
@@ -20,6 +20,9 @@ export class ProgressService {
       return;
     }
     const uid = this.auth.getCurrentUserId();
+    if (!uid) {
+      return;
+    }
     const board = this.appState.getBoard();
     const standard = this.appState.getStandard();
     const ref = doc(this.firestore, `Users/${uid}`);
@@ -39,6 +42,9 @@ export class ProgressService {
       return;
     }
     const uid = this.auth.getCurrentUserId();
+    if (!uid) {
+      return;
+    }
     const board = this.appState.getBoard();
     const standard = this.appState.getStandard();
     const ref = doc(this.firestore, `Users/${uid}`);
@@ -53,6 +59,9 @@ export class ProgressService {
 
   getProgress(subjectId: string): Observable<any | undefined> {
     const uid = this.auth.getCurrentUserId();
+    if (!uid) {
+      return of(undefined);
+    }
     const board = this.appState.getBoard();
     const standard = this.appState.getStandard();
     const ref = doc(this.firestore, `Users/${uid}`);

--- a/Orynth/src/app/services/snackbar.service.ts
+++ b/Orynth/src/app/services/snackbar.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+import { MatSnackBar, MatSnackBarRef, SimpleSnackBar } from '@angular/material/snack-bar';
+
+@Injectable({ providedIn: 'root' })
+export class SnackbarService {
+  private ref?: MatSnackBarRef<SimpleSnackBar>;
+
+  constructor(private snackBar: MatSnackBar) {}
+
+  show(message: string) {
+    if (this.ref) {
+      this.ref.dismiss();
+    }
+    this.ref = this.snackBar.open(message, 'Close', { duration: 3000 });
+  }
+}

--- a/Orynth/src/app/services/test-results.service.ts
+++ b/Orynth/src/app/services/test-results.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@angular/core';
+import { Firestore, doc, updateDoc, arrayUnion, docData } from '@angular/fire/firestore';
+import { AuthService } from './auth.service';
+import { AppStateService } from './app-state.service';
+import { Observable, map } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class TestResultsService {
+  constructor(
+    private firestore: Firestore,
+    private auth: AuthService,
+    private appState: AppStateService
+  ) {}
+
+  async addResult(subjectId: string, chapter: string, result: any) {
+    if (!this.auth.isLoggedIn()) {
+      return;
+    }
+    const uid = this.auth.getCurrentUserId();
+    const board = this.appState.getBoard();
+    const standard = this.appState.getStandard();
+    const ref = doc(this.firestore, `Users/${uid}`);
+    const field = `testResults.${board}.${standard}.${subjectId}.${chapter}`;
+    await updateDoc(ref, { [field]: arrayUnion(result) });
+  }
+
+  getResults(subjectId: string, chapter: string): Observable<any[]> {
+    const uid = this.auth.getCurrentUserId();
+    const board = this.appState.getBoard();
+    const standard = this.appState.getStandard();
+    const ref = doc(this.firestore, `Users/${uid}`);
+    return docData(ref).pipe(
+      map(data => (data as any)?.testResults?.[board]?.[standard]?.[subjectId]?.[chapter] || [])
+    );
+  }
+}

--- a/Orynth/src/app/services/test-results.service.ts
+++ b/Orynth/src/app/services/test-results.service.ts
@@ -1,15 +1,17 @@
 import { Injectable } from '@angular/core';
 import { Firestore, doc, updateDoc, arrayUnion, docData } from '@angular/fire/firestore';
-import { of, Observable, map } from 'rxjs';
+import { of, Observable, map, catchError } from 'rxjs';
 import { AuthService } from './auth.service';
 import { AppStateService } from './app-state.service';
+import { SnackbarService } from './snackbar.service';
 
 @Injectable({ providedIn: 'root' })
 export class TestResultsService {
   constructor(
     private firestore: Firestore,
     private auth: AuthService,
-    private appState: AppStateService
+    private appState: AppStateService,
+    private snackbar: SnackbarService
   ) {}
 
   async addResult(subjectId: string, chapter: string, result: any) {
@@ -22,7 +24,14 @@ export class TestResultsService {
     const standard = this.appState.getStandard();
     const ref = doc(this.firestore, `Users/${uid}`);
     const field = `testResults.${board}.${standard}.${subjectId}.${chapter}`;
-    await updateDoc(ref, { [field]: arrayUnion(result) });
+    try {
+      await updateDoc(ref, { [field]: arrayUnion(result) });
+      this.snackbar.show('Result saved');
+      console.log('Result saved');
+    } catch (err) {
+      console.error('Error saving result', err);
+      this.snackbar.show('Error saving result');
+    }
   }
 
   getResults(subjectId: string, chapter: string): Observable<any[]> {
@@ -32,7 +41,16 @@ export class TestResultsService {
     const standard = this.appState.getStandard();
     const ref = doc(this.firestore, `Users/${uid}`);
     return docData(ref).pipe(
-      map(data => (data as any)?.testResults?.[board]?.[standard]?.[subjectId]?.[chapter] || [])
+      map(data => (data as any)?.testResults?.[board]?.[standard]?.[subjectId]?.[chapter] || []),
+      catchError(err => {
+        console.error('Error loading results', err);
+        this.snackbar.show('Error loading results');
+        return of([]);
+      }),
+      map(res => {
+        console.log('Results loaded');
+        return res;
+      })
     );
   }
 }

--- a/Orynth/src/app/services/test-results.service.ts
+++ b/Orynth/src/app/services/test-results.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@angular/core';
 import { Firestore, doc, updateDoc, arrayUnion, docData } from '@angular/fire/firestore';
+import { of, Observable, map } from 'rxjs';
 import { AuthService } from './auth.service';
 import { AppStateService } from './app-state.service';
-import { Observable, map } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })
 export class TestResultsService {
@@ -17,6 +17,7 @@ export class TestResultsService {
       return;
     }
     const uid = this.auth.getCurrentUserId();
+    if (!uid) return;
     const board = this.appState.getBoard();
     const standard = this.appState.getStandard();
     const ref = doc(this.firestore, `Users/${uid}`);
@@ -26,6 +27,7 @@ export class TestResultsService {
 
   getResults(subjectId: string, chapter: string): Observable<any[]> {
     const uid = this.auth.getCurrentUserId();
+    if (!uid) return of([]);
     const board = this.appState.getBoard();
     const standard = this.appState.getStandard();
     const ref = doc(this.firestore, `Users/${uid}`);

--- a/Orynth/src/styles.scss
+++ b/Orynth/src/styles.scss
@@ -1,6 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+@import '@angular/material/prebuilt-themes/indigo-pink.css';
 
 /* Design system variables and utilities */
 @layer base {

--- a/README.md
+++ b/README.md
@@ -88,3 +88,9 @@ result in an `Invalid document reference` error.
 - **Auth Layer – ✅ Done**
   - Anonymous login and IndexedDB persistence enabled
 
+## Versioning
+
+The app version is shown in `bottom-nav.html`. Bump the patch version by one
+with each commit unless a specific version is requested. For example,
+increment `v0.0.1` to `v0.0.2` when updating the code.
+


### PR DESCRIPTION
## Summary
- add new `TestResultsService`
- create **AddTestResultsPage** for entering marks
- show '+' icon on chapter cards leading to new page
- wire up new `/add-test-results` route

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686f83088378832eaece8ac89a33e2f4