### PR TITLE
Add feedback form for missing board or standard

### DIFF
--- a/Orynth/src/app/app.routes.ts
+++ b/Orynth/src/app/app.routes.ts
@@ -40,6 +40,10 @@ export const routes: Routes = [
     loadComponent: () => import('./pages/add-test-results/add-test-results-page').then(m => m.AddTestResultsPageComponent)
   },
   {
+    path: 'feedback',
+    loadComponent: () => import('./pages/feedback/feedback-page').then(m => m.FeedbackPageComponent)
+  },
+  {
     path: 'logs',
     loadComponent: () => import('./pages/logs/logs-page').then(m => m.LogsPageComponent)
   },

--- a/Orynth/src/app/components/bottom-nav/bottom-nav.html
+++ b/Orynth/src/app/components/bottom-nav/bottom-nav.html
@@ -23,7 +23,7 @@
     <p class="text-xs text-gray-500">
       Powered by Growth Tutorials -
       <a routerLink="/logs" class="underline tap-highlight">Logs</a> -
-      <span (click)="reloadApp()" class="underline cursor-pointer tap-highlight">v0.0.10</span>
+      <span (click)="reloadApp()" class="underline cursor-pointer tap-highlight">v0.0.11</span>
     </p>
   </div>
 </div>

--- a/Orynth/src/app/components/bottom-nav/bottom-nav.html
+++ b/Orynth/src/app/components/bottom-nav/bottom-nav.html
@@ -23,7 +23,7 @@
     <p class="text-xs text-gray-500">
       Powered by Growth Tutorials -
       <a routerLink="/logs" class="underline tap-highlight">Logs</a> -
-      <span (click)="reloadApp()" class="underline cursor-pointer tap-highlight">v0.0.11</span>
+      <span (click)="reloadApp()" class="underline cursor-pointer tap-highlight">v0.0.12</span>
     </p>
   </div>
 </div>

--- a/Orynth/src/app/components/bottom-nav/bottom-nav.html
+++ b/Orynth/src/app/components/bottom-nav/bottom-nav.html
@@ -23,7 +23,7 @@
     <p class="text-xs text-gray-500">
       Powered by Growth Tutorials -
       <a routerLink="/logs" class="underline tap-highlight">Logs</a> -
-      <span (click)="reloadApp()" class="underline cursor-pointer tap-highlight">v0.0.12</span>
+      <span (click)="reloadApp()" class="underline cursor-pointer tap-highlight">v0.0.13</span>
     </p>
   </div>
 </div>

--- a/Orynth/src/app/components/bottom-nav/bottom-nav.html
+++ b/Orynth/src/app/components/bottom-nav/bottom-nav.html
@@ -23,7 +23,7 @@
     <p class="text-xs text-gray-500">
       Powered by Growth Tutorials -
       <a routerLink="/logs" class="underline tap-highlight">Logs</a> -
-      <span (click)="reloadApp()" class="underline cursor-pointer tap-highlight">v0.0.13</span>
+      <span (click)="reloadApp()" class="underline cursor-pointer tap-highlight">v0.0.14</span>
     </p>
   </div>
 </div>

--- a/Orynth/src/app/pages/board-class-selection/board-class-selection-page.html
+++ b/Orynth/src/app/pages/board-class-selection/board-class-selection-page.html
@@ -44,6 +44,6 @@
   <div class="p-6">
     <button *ngIf="step === 1" (click)="nextStep()" [disabled]="!selectedBoard" class="w-full h-14 text-lg font-semibold bg-primary hover:bg-primary/90 text-white rounded-xl card-shadow hover:card-shadow-hover tap-highlight disabled:opacity-50 disabled:cursor-not-allowed">Continue</button>
     <button *ngIf="step === 2" (click)="startLearning()" [disabled]="!selectedClass" class="w-full h-14 flex items-center justify-center text-lg font-semibold bg-primary hover:bg-primary/90 text-white rounded-xl card-shadow hover:card-shadow-hover tap-highlight disabled:opacity-50 disabled:cursor-not-allowed">Start Learning</button>
-    <a routerLink="/feedback" class="block text-center text-sm text-primary mt-4">Not finding what you are looking for? Let us know!</a>
+    <a routerLink="/feedback" class="block text-center text-sm text-primary mt-4 underline tap-highlight">Not finding what you are looking for? Let us know!</a>
   </div>
 </div>

--- a/Orynth/src/app/pages/board-class-selection/board-class-selection-page.html
+++ b/Orynth/src/app/pages/board-class-selection/board-class-selection-page.html
@@ -44,5 +44,6 @@
   <div class="p-6">
     <button *ngIf="step === 1" (click)="nextStep()" [disabled]="!selectedBoard" class="w-full h-14 text-lg font-semibold bg-primary hover:bg-primary/90 text-white rounded-xl card-shadow hover:card-shadow-hover tap-highlight disabled:opacity-50 disabled:cursor-not-allowed">Continue</button>
     <button *ngIf="step === 2" (click)="startLearning()" [disabled]="!selectedClass" class="w-full h-14 flex items-center justify-center text-lg font-semibold bg-primary hover:bg-primary/90 text-white rounded-xl card-shadow hover:card-shadow-hover tap-highlight disabled:opacity-50 disabled:cursor-not-allowed">Start Learning</button>
+    <a routerLink="/feedback" class="block text-center text-sm text-primary mt-4">Not finding what you are looking for? Let us know!</a>
   </div>
 </div>

--- a/Orynth/src/app/pages/feedback/feedback-page.html
+++ b/Orynth/src/app/pages/feedback/feedback-page.html
@@ -1,0 +1,29 @@
+<div class="min-h-screen bg-gradient-to-br from-blue-50 to-green-50 flex flex-col">
+  <div class="flex items-center justify-between p-4">
+    <button (click)="goBack()" class="p-2 hover:bg-white/20 rounded-full tap-highlight">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-6 h-6 text-gray-700">
+        <polyline points="15 18 9 12 15 6"></polyline>
+      </svg>
+    </button>
+    <h1 class="text-lg font-semibold text-gray-900">Feedback</h1>
+    <div class="w-10"></div>
+  </div>
+  <div class="flex-1 px-6 pt-6 pb-8">
+    <div class="max-w-sm mx-auto space-y-4">
+      <div>
+        <label class="text-sm font-medium text-gray-900">Board</label>
+        <input [(ngModel)]="board" class="w-full h-12 bg-gray-50 rounded-xl border-gray-200 mt-1" placeholder="Your board" />
+      </div>
+      <div>
+        <label class="text-sm font-medium text-gray-900">Standard</label>
+        <input [(ngModel)]="standard" class="w-full h-12 bg-gray-50 rounded-xl border-gray-200 mt-1" placeholder="Your class" />
+      </div>
+      <div>
+        <label class="text-sm font-medium text-gray-900">Message</label>
+        <textarea [(ngModel)]="message" rows="4" class="w-full bg-gray-50 rounded-xl border-gray-200 mt-1 p-2" placeholder="Tell us what you need"></textarea>
+      </div>
+      <button (click)="submit()" class="w-full h-12 bg-primary text-white rounded-xl">Submit</button>
+      <p *ngIf="submitted" class="text-center text-green-600">Thank you for your feedback!</p>
+    </div>
+  </div>
+</div>

--- a/Orynth/src/app/pages/feedback/feedback-page.ts
+++ b/Orynth/src/app/pages/feedback/feedback-page.ts
@@ -1,0 +1,43 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
+import { Firestore, collection, addDoc } from '@angular/fire/firestore';
+import { AuthService } from '../../services/auth.service';
+
+@Component({
+  selector: 'app-feedback-page',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './feedback-page.html'
+})
+export class FeedbackPageComponent {
+  board = '';
+  standard = '';
+  message = '';
+  submitted = false;
+
+  constructor(
+    private router: Router,
+    private firestore: Firestore,
+    private auth: AuthService
+  ) {}
+
+  async submit() {
+    await addDoc(collection(this.firestore, 'user_feedback'), {
+      uid: this.auth.getCurrentUserId() || null,
+      board: this.board,
+      standard: this.standard,
+      message: this.message,
+      timestamp: new Date().toISOString()
+    });
+    this.board = '';
+    this.standard = '';
+    this.message = '';
+    this.submitted = true;
+  }
+
+  goBack() {
+    this.router.navigate(['/board-class-selection']);
+  }
+}

--- a/Orynth/src/app/services/test-results.service.ts
+++ b/Orynth/src/app/services/test-results.service.ts
@@ -24,13 +24,15 @@ export class TestResultsService {
 
     console.log('Attempting to save result', { uid, board, standard, subjectId, chapter, result });
 
-    if (!uid || !board || !standard || !subjectId || !chapter) {
+    if (!uid || !board || !standard || !subjectId) {
       console.error('Missing data for saving result', { uid, board, standard, subjectId, chapter });
       this.snackbar.show('Error saving result');
       return;
     }
 
-    const sanitizedChapter = chapter.replace(/[.#$\[\]/]/g, '_');
+    const sanitizedChapter = chapter
+      ? chapter.replace(/[.#$\[\]/]/g, '_')
+      : 'general';
     const ref = doc(this.firestore, `Users/${uid}`);
     const field = `testResults.${board}.${standard}.${subjectId}.${sanitizedChapter}`;
     try {
@@ -48,7 +50,9 @@ export class TestResultsService {
     if (!uid) return of([]);
     const board = this.appState.getBoard();
     const standard = this.appState.getStandard();
-    const sanitizedChapter = chapter.replace(/[.#$\[\]/]/g, '_');
+    const sanitizedChapter = chapter
+      ? chapter.replace(/[.#$\[\]/]/g, '_')
+      : 'general';
     const ref = doc(this.firestore, `Users/${uid}`);
     return docData(ref).pipe(
       map(data => (data as any)?.testResults?.[board]?.[standard]?.[subjectId]?.[sanitizedChapter] || []),

--- a/Orynth/src/app/services/test-results.service.ts
+++ b/Orynth/src/app/services/test-results.service.ts
@@ -19,15 +19,24 @@ export class TestResultsService {
       return;
     }
     const uid = this.auth.getCurrentUserId();
-    if (!uid) return;
     const board = this.appState.getBoard();
     const standard = this.appState.getStandard();
+
+    console.log('Attempting to save result', { uid, board, standard, subjectId, chapter, result });
+
+    if (!uid || !board || !standard || !subjectId || !chapter) {
+      console.error('Missing data for saving result', { uid, board, standard, subjectId, chapter });
+      this.snackbar.show('Error saving result');
+      return;
+    }
+
+    const sanitizedChapter = chapter.replace(/[.#$\[\]/]/g, '_');
     const ref = doc(this.firestore, `Users/${uid}`);
-    const field = `testResults.${board}.${standard}.${subjectId}.${chapter}`;
+    const field = `testResults.${board}.${standard}.${subjectId}.${sanitizedChapter}`;
     try {
       await updateDoc(ref, { [field]: arrayUnion(result) });
       this.snackbar.show('Result saved');
-      console.log('Result saved');
+      console.log('Result saved', result);
     } catch (err) {
       console.error('Error saving result', err);
       this.snackbar.show('Error saving result');
@@ -39,16 +48,17 @@ export class TestResultsService {
     if (!uid) return of([]);
     const board = this.appState.getBoard();
     const standard = this.appState.getStandard();
+    const sanitizedChapter = chapter.replace(/[.#$\[\]/]/g, '_');
     const ref = doc(this.firestore, `Users/${uid}`);
     return docData(ref).pipe(
-      map(data => (data as any)?.testResults?.[board]?.[standard]?.[subjectId]?.[chapter] || []),
+      map(data => (data as any)?.testResults?.[board]?.[standard]?.[subjectId]?.[sanitizedChapter] || []),
       catchError(err => {
         console.error('Error loading results', err);
         this.snackbar.show('Error loading results');
         return of([]);
       }),
       map(res => {
-        console.log('Results loaded');
+        console.log('Results loaded', res);
         return res;
       })
     );

--- a/Orynth/src/app/services/test-results.service.ts
+++ b/Orynth/src/app/services/test-results.service.ts
@@ -30,9 +30,13 @@ export class TestResultsService {
       return;
     }
 
-    const sanitizedChapter = chapter
-      ? chapter.replace(/[.#$\[\]/]/g, '_')
-      : 'general';
+    if (!chapter) {
+      console.error('Cannot save result: no chapter provided');
+      this.snackbar.show('Chapter not specified');
+      return;
+    }
+
+    const sanitizedChapter = chapter.replace(/[.#$\[\]/]/g, '_');
     const ref = doc(this.firestore, `Users/${uid}`);
     const field = `testResults.${board}.${standard}.${subjectId}.${sanitizedChapter}`;
     try {
@@ -50,9 +54,13 @@ export class TestResultsService {
     if (!uid) return of([]);
     const board = this.appState.getBoard();
     const standard = this.appState.getStandard();
-    const sanitizedChapter = chapter
-      ? chapter.replace(/[.#$\[\]/]/g, '_')
-      : 'general';
+
+    if (!chapter) {
+      console.error('Cannot load results: no chapter provided');
+      return of([]);
+    }
+
+    const sanitizedChapter = chapter.replace(/[.#$\[\]/]/g, '_');
     const ref = doc(this.firestore, `Users/${uid}`);
     return docData(ref).pipe(
       map(data => (data as any)?.testResults?.[board]?.[standard]?.[subjectId]?.[sanitizedChapter] || []),


### PR DESCRIPTION
## Summary
- link to feedback form from board/class selection
- create feedback page with form fields for board, class and message
- store feedback to Firestore collection `user_feedback`
- add route for feedback page
- bump app version to v0.0.11

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68846768aed8832e8b90264672852c50