### PR TITLE
Fix chapter selection for results

### DIFF
--- a/Orynth/src/app/components/bottom-nav/bottom-nav.html
+++ b/Orynth/src/app/components/bottom-nav/bottom-nav.html
@@ -23,7 +23,7 @@
     <p class="text-xs text-gray-500">
       Powered by Growth Tutorials -
       <a routerLink="/logs" class="underline tap-highlight">Logs</a> -
-      <span (click)="reloadApp()" class="underline cursor-pointer tap-highlight">v0.0.14</span>
+      <span (click)="reloadApp()" class="underline cursor-pointer tap-highlight">v0.0.15</span>
     </p>
   </div>
 </div>

--- a/Orynth/src/app/pages/add-test-results/add-test-results-page.ts
+++ b/Orynth/src/app/pages/add-test-results/add-test-results-page.ts
@@ -29,7 +29,8 @@ export class AddTestResultsPageComponent implements OnInit {
 
   ngOnInit(): void {
     const nav = this.router.getCurrentNavigation();
-    this.chapter = nav?.extras.state?.['chapter'] || '';
+    const state = nav?.extras.state || history.state;
+    this.chapter = state?.['chapter'] || '';
     this.subject = this.appState.getSubject();
     this.loadResults();
   }


### PR DESCRIPTION
## Summary
- retain router state on refresh when adding test results
- bump version in bottom nav

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6885a38b43ec832e8885015cef86d138