### PR TITLE
Fix chapter progress results display

### DIFF
--- a/Orynth/src/app/components/bottom-nav/bottom-nav.html
+++ b/Orynth/src/app/components/bottom-nav/bottom-nav.html
@@ -23,7 +23,7 @@
     <p class="text-xs text-gray-500">
       Powered by Growth Tutorials -
       <a routerLink="/logs" class="underline tap-highlight">Logs</a> -
-      <span (click)="reloadApp()" class="underline cursor-pointer tap-highlight">v0.0.17</span>
+      <span (click)="reloadApp()" class="underline cursor-pointer tap-highlight">v0.0.18</span>
     </p>
   </div>
 </div>

--- a/Orynth/src/app/pages/chapter-tracker/chapter-tracker-page.ts
+++ b/Orynth/src/app/pages/chapter-tracker/chapter-tracker-page.ts
@@ -74,9 +74,12 @@ export class ChapterTrackerPageComponent implements OnInit, OnDestroy {
 
       this.progressSub = this.progressService.getProgress(subject).subscribe(remote => {
         if (remote && Array.isArray(remote)) {
-          this.chapters = this.chapters.map(c => {
-            const match = remote.find((s: any) => s.id === c.id && s.name === c.name);
-            return match ? { ...c, status: match.status, confidence: match.confidence } : c;
+          this.chapters.forEach(ch => {
+            const match = remote.find((s: any) => s.id === ch.id && s.name === ch.name);
+            if (match) {
+              ch.status = match.status;
+              ch.confidence = match.confidence;
+            }
           });
           localStorage.setItem(`${subject}-progress`, JSON.stringify(this.chapters));
         }


### PR DESCRIPTION
## Summary
- keep chapter objects stable when syncing progress
- bump footer version

## Testing
- `npm run build`
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6885ba52b918832ea67d95fb1ed332cb